### PR TITLE
Add an example of multiple scopes one API with different consent Status

### DIFF
--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -198,7 +198,7 @@ paths:
                         consentRequired: true
                         consentStatus: PENDING
                     captureUrl: 'https://example.org/consent-capture-url'
-                CONSENT_REQUIRED_MULTIPLES_SCOPES_MULTIPLE_CONSENTS_ONE_API:
+                MULTIPLES_SCOPES_ONE_API_DIFFERENT_CONSENT_STATUS:
                   summary: Multiple scopes for one API with different consentStatus
                   description: |
                     Request with multiple scopes corresponding to one API. Different Consent status for each scope.

--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -198,6 +198,22 @@ paths:
                         consentRequired: true
                         consentStatus: PENDING
                     captureUrl: 'https://example.org/consent-capture-url'
+                CONSENT_REQUIRED_MULTIPLES_SCOPES_MULTIPLE_CONSENTS_ONE_API:
+                  summary: Multiple scopes for one API with different consentStatus
+                  description: |
+                    Consent is required for the requested scope(s) and Purpose but it is not provided by the User. Request with multiple scopes corresponding to one API.
+                  value:
+                    privacyStatus:
+                      - scopes:
+                          - "sim-swap:check"
+                        purpose: "dpv:FraudPreventionAndDetection"
+                        consentRequired: false
+                      - scopes:
+                          - "sim-swap:retrieve-date"
+                        purpose: "dpv:FraudPreventionAndDetection"
+                        consentRequired: true
+                        consentStatus: PENDING
+                    captureUrl: 'https://example.org/consent-capture-url'
         "400":
           $ref: "#/components/responses/Generic400"
         "401":

--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -201,7 +201,7 @@ paths:
                 CONSENT_REQUIRED_MULTIPLES_SCOPES_MULTIPLE_CONSENTS_ONE_API:
                   summary: Multiple scopes for one API with different consentStatus
                   description: |
-                    Consent is required for the requested scope(s) and Purpose but it is not provided by the User. Request with multiple scopes corresponding to one API.
+                    Request with multiple scopes corresponding to one API. Different Consent status for each scope.
                   value:
                     privacyStatus:
                       - scopes:


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature
* documentation

#### What this PR does / why we need it:

Add an example of multiple scopes corresponding to one API with different consent Status.

#### Which issue(s) this PR fixes:

Fixes #12

#### Special notes for reviewers:

CC @subha5h

#### Changelog input

```
Example of multiple scopes one API with different consent Status
```

#### Additional documentation 

N/A
