### PR TITLE
Updated consent-info.yaml to support multiple purposes

### DIFF
--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -92,9 +92,10 @@ paths:
                   Request with one scope corresponding to one API
                 value:
                   phoneNumber: "+123456789"
-                  scopes:
-                    - "location-verification:verify"
-                  purpose: "dpv:FraudPreventionAndDetection"
+                  purposeAndScopes:
+                    - scopes:
+                        - "location-verification:verify"
+                      purpose: "dpv:FraudPreventionAndDetection"
                   requestCaptureUrl: true
               MULTIPLE_SCOPES_ONE_API:
                 summary: Multiple scopes for one API
@@ -102,13 +103,14 @@ paths:
                   Request with multiple scopes corresponding to one API
                 value:
                   phoneNumber: "+123456789"
-                  scopes:
-                    - "quality-on-demand:sessions:create"
-                    - "quality-on-demand:sessions:read"
-                    - "quality-on-demand:sessions:update"
-                    - "quality-on-demand:sessions:delete"
-                    - "quality-on-demand:sessions:retrieve-by-device"
-                  purpose: "dpv:RequestedServiceProvision"
+                  purposeAndScopes:
+                    - scopes:
+                        - "quality-on-demand:sessions:create"
+                        - "quality-on-demand:sessions:read"
+                        - "quality-on-demand:sessions:update"
+                        - "quality-on-demand:sessions:delete"
+                        - "quality-on-demand:sessions:retrieve-by-device"
+                      purpose: "dpv:RequestedServiceProvision"
                   requestCaptureUrl: true
               MULTIPLE_SCOPES_MULTIPLE_APIS:
                 summary: Multiple scopes for multiple APIs
@@ -116,10 +118,29 @@ paths:
                   Request with multiple scopes corresponding to multiple APIs
                 value:
                   phoneNumber: "+123456789"
-                  scopes:
-                    - "location-verification:verify"
-                    - "device-roaming-status:read"
-                  purpose: "dpv:FraudPreventionAndDetection"
+                  purposeAndScopes:
+                    - scopes:
+                        - "location-verification:verify"
+                        - "device-roaming-status:read"
+                      purpose: "dpv:FraudPreventionAndDetection"
+                  requestCaptureUrl: true
+              MULTIPLE_PURPOSES_MULTIPLE_SCOPES_MULTIPLE_APIS:
+                summary: Multiple scopes for multiple APIs
+                description: |
+                  Request with multiple scopes corresponding to multiple APIs
+                value:
+                  phoneNumber: "+123456789"
+                  purposeAndScopes:
+                    - scopes:
+                        - "location-verification:verify"
+                      purpose: "dpv:FraudPreventionAndDetection"
+                    - scopes:
+                        - "quality-on-demand:sessions:create"
+                        - "quality-on-demand:sessions:read"
+                        - "quality-on-demand:sessions:update"
+                        - "quality-on-demand:sessions:delete"
+                        - "quality-on-demand:sessions:retrieve-by-device"
+                      purpose: "dpv:RequestedServiceProvision"
                   requestCaptureUrl: true
       responses:
         "200":
@@ -249,16 +270,15 @@ components:
     VerifyConsentStatusRequestBody:
       type: object
       required:
-        - scopes
-        - purpose
+        - PurposeAndDataScope
         - requestCaptureUrl
       properties:
         phoneNumber:
           $ref: "#/components/schemas/PhoneNumber"
-        scopes:
-          $ref: "#/components/schemas/Scopes"
-        purpose:
-          $ref: "#/components/schemas/Purpose"
+        purposesAndScopes:
+          type: array
+          items:
+            $ref: "#/components/schemas/PurposeAndScopes"
         requestCaptureUrl:
           type: boolean
           description: |
@@ -266,6 +286,15 @@ components:
             * `true` - If set to `true` the API will include a `captureUrl` in the response body if applicable.
             * `false` - The API will omit the consent capture URL from the response.
           example: true
+    PurposeAndScopes:
+      type: object
+      description: >
+        A list of data-scopes and their corresponding purposes
+      properties:
+        scopes:
+          $ref: "#/components/schemas/Scopes"
+        purpose:
+          $ref: "#/components/schemas/Purpose"
     Scopes:
       type: array
       minItems: 1


### PR DESCRIPTION
Updated the API spec to support multiple purpose in request schema as discussed in issue #11

#### What type of PR is this?

Add one of the following kinds:
* enhancement/feature


#### What this PR does / why we need it:

Enhances the API request schema to allow an API invoker to request status for multiple purposes (and scopes).


#### Which issue(s) this PR fixes:

Fixes # 13

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

