### PR TITLE
API Spec update

### DIFF
--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -17,7 +17,7 @@ info:
     * **Purpose**: The reason for which Personal Data will be processed by an API Consumer. CAMARA defines a standard set of Purposes which can be used by API Consumers to specify the reason for their intended Personal Data processing.
     * **Scope**: A string representing the specific access rights or actions an API Consumer requests from the User for their data (e.g., "location-verification:verify"). A request can contain multiple scopes.
     * **Legal Basis**: The justification under data protection law for processing Personal Data. It identifies the lawful ground on which the API Consumer relies (e.g., Consent, Contract, Legitimate Interest).
-    
+   
     This API adopts the [W3C Data Privacy Vocabulary](https://w3c.github.io/dpv/2.0/dpv/) (DPV) to represent both Purpose and Legal Basis. For example, Legal Basis include values such as `dpv:Consent` or `dpv:LegitimateInterest`, while Purposes include `dpv:FraudPreventionAndDetection` or `dpv:RequestedServiceProvision`.
 
     # API Functionality

--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -17,7 +17,7 @@ info:
     * **Purpose**: The reason for which Personal Data will be processed by an API Consumer. CAMARA defines a standard set of Purposes which can be used by API Consumers to specify the reason for their intended Personal Data processing.
     * **Scope**: A string representing the specific access rights or actions an API Consumer requests from the User for their data (e.g., "location-verification:verify"). A request can contain multiple scopes.
     * **Legal Basis**: The justification under data protection law for processing Personal Data. It identifies the lawful ground on which the API Consumer relies (e.g., Consent, Contract, Legitimate Interest).
-   
+
     This API adopts the [W3C Data Privacy Vocabulary](https://w3c.github.io/dpv/2.0/dpv/) (DPV) to represent both Purpose and Legal Basis. For example, Legal Basis include values such as `dpv:Consent` or `dpv:LegitimateInterest`, while Purposes include `dpv:FraudPreventionAndDetection` or `dpv:RequestedServiceProvision`.
 
     # API Functionality

--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -27,7 +27,7 @@ info:
     Specifically, the API:
 
     * Indicates the applicable Legal Basis: Indicates which legal basis (e.g., `dpv:Consent`, `dpv:LegitimateInterest`) is required for the requested scopes, Purpose, and API Consumer according to relevant legal frameworks.
-    * Provides the data processing validity status and reason: If a legal basis is required, the API returns `statusValidForProcessing`, a boolean flag that is `true` if processing is permitted. If the flag is `false`, a `statusReason` field (with values like `PENDING`, `REVOKED`, `EXPIRED`) is also returned to explain why.
+    * Provides the data processing validity status and reason: The API returns `statusValidForProcessing`, a boolean flag that is `true` if processing is permitted. If the flag is `false`, a `statusReason` field is also returned to explain why.
     * Offers a Consent Capture URL: This functionality is specific to the `dpv:Consent` legal basis. If the API Consumer sets `requestCaptureUrl` to `true`, and if a user needs to provide or renew their Consent (e.g., the `statusReason` is `PENDING` or `EXPIRED`), the API supplies the API Provider's Consent capture URL.
 
     Importantly, this API does NOT delegate Consent capture to the API Consumer but rather empowers the API Consumer to present the API Provider's Consent capture URL at the most opportune time and place. The actual Consent capture occurs within the API Provider's secure environment, ensuring the User's authentication with the API Provider.

--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -77,7 +77,7 @@ paths:
       summary: Create a request to verify the status of Consent or other Legal Basis
       description: |
         Create a request to verify the Consent or other Legal Basis of a specific User to the API Consumer for the requested scope(s) and Purpose. The API Consumer is identified by the `client_id` parameter deduced from the access token.
-      operationId: verifyConsentStatus
+      operationId: verifyStatus
       security:
         - openId:
             - consent-info:verify

--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -9,14 +9,16 @@ info:
 
     # Introduction
 
-    The primary function of this API is to enable API Consumers to ascertain the authorization status for processing personal data before using other APIs. By providing a standardized way to check the validity of a legal basis, this API facilitates compliance with privacy regulations and promotes transparency with users. Key inputs include the specific scope(s) of access being requested, the Purpose for data processing, and an identifier for the User (either explicitly provided or derived from a three-legged access token). The API responds with the validity status of the applicable Legal Basis, and, if the Legal Basis is `dpv:Consent`, can provide a URL for the User to manage it.
+    The primary function of this API is to enable API Consumers to ascertain the authorization status for processing personal data before using other APIs. By providing a standardized way to check the validity of a legal basis, this API facilitates compliance with privacy regulations and promotes transparency with users. Key inputs include the specific scope(s) of access being requested, the Purpose for data processing, and an identifier for the User (either explicitly provided or derived from a three-legged access token). The API responds with the validity status of the applicable Legal Basis, and, if the Legal Basis is `dpv:Consent`, can provide a URL for the API Consumer to manage it.
 
     # Relevant terms and definitions
 
     * **Consent**: An explicit opt-in action that the User takes to allow processing of Personal Data. Consent grants the API Consumer access to a set of scopes related to the User for a specific Purpose.
     * **Purpose**: The reason for which Personal Data will be processed by an API Consumer. CAMARA defines a standard set of Purposes which can be used by API Consumers to specify the reason for their intended Personal Data processing.
     * **Scope**: A string representing the specific access rights or actions an API Consumer requests from the User for their data (e.g., "location-verification:verify"). A request can contain multiple scopes.
-    * **Legal Basis**: The justification under data protection law for processing Personal Data. This API uses terms from the W3C Data Privacy Vocabulary (DPV), such as `dpv:Consent`, `dpv:LegitimateInterest`, `dpv:Contract`, etc., to indicate the relevant legal ground.
+    * **Legal Basis**: The justification under data protection law for processing Personal Data. It identifies the lawful ground on which the API Consumer relies (e.g., Consent, Contract, Legitimate Interest).
+    
+    This API adopts the [W3C Data Privacy Vocabulary](https://w3c.github.io/dpv/2.0/dpv/) (DPV) to represent both Purpose and Legal Basis. For example, Legal Basis include values such as `dpv:Consent` or `dpv:LegitimateInterest`, while Purposes include `dpv:FraudPreventionAndDetection` or `dpv:RequestedServiceProvision`.
 
     # API Functionality
 

--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -28,7 +28,7 @@ info:
 
     * Indicates the applicable Legal Basis: Indicates which legal basis (e.g., `dpv:Consent`, `dpv:LegitimateInterest`) is required for the requested scopes, Purpose, and API Consumer according to relevant legal frameworks.
     * Provides the data processing validity status and reason: The API returns `statusValidForProcessing`, a boolean flag that is `true` if processing is permitted. If the flag is `false`, a `statusReason` field is also returned to explain why.
-    * Offers a Consent Capture URL: This functionality is specific to the `dpv:Consent` legal basis. If the API Consumer sets `requestCaptureUrl` to `true`, and if a user needs to provide or renew their Consent (e.g., the `statusReason` is `PENDING` or `EXPIRED`), the API supplies the API Provider's Consent capture URL.
+    * Offers a Consent Capture URL: This functionality is specific to the `dpv:Consent` legal basis. If the API Consumer sets `requestCaptureUrl` to `true`, and if a user needs to provide or renew their Consent, the API supplies the API Provider's Consent capture URL.
 
     Importantly, this API does NOT delegate Consent capture to the API Consumer but rather empowers the API Consumer to present the API Provider's Consent capture URL at the most opportune time and place. The actual Consent capture occurs within the API Provider's secure environment, ensuring the User's authentication with the API Provider.
 
@@ -162,7 +162,7 @@ paths:
                         purpose: "dpv:FraudPreventionAndDetection"
                         legalBasis: "dpv:Consent"
                         statusValidForProcessing: false
-                        statusReason: PENDING
+                        statusReason: REQUESTED
                 CONSENT_REQUIRED_CAPTURE_URL:
                   summary: Consent is required and capture URL is provided
                   description: |
@@ -331,7 +331,7 @@ components:
           type: string
           format: url
           description: |
-            URL where the User can provide the necessary Consent. This field is only present if requested by the API Consumer and if `statusInfo[*].legalBasis` is `dpv:Consent`, `statusInfo[*].statusValidForProcessing` is `false`, and `statusInfo[*].statusReason` is `PENDING` or `EXPIRED`.
+            URL where the User can provide the necessary Consent. This field is only present if requested by the API Consumer and if `statusInfo[*].legalBasis` is `dpv:Consent`, `statusInfo[*].statusValidForProcessing` is `false`, and `statusInfo[*].statusReason` is `PENDING`, `REQUESTED` or `EXPIRED`.
           example: 'https://example.org/consent-capture-url'
     statusInfo:
       type: array
@@ -374,6 +374,7 @@ components:
           type: string
           enum:
             - PENDING
+            - REQUESTED
             - REVOKED
             - EXPIRED
           description: |
@@ -382,6 +383,8 @@ components:
               Possible values are:
               - `PENDING`: The specified `legalBasis` is not yet established or fully validated for the requested data processing.
                            For example, the user has not yet provided Consent under `dpv:Consent` Legal Basis.
+              - `REQUESTED`: Where applicable, the specified `legalBasis` has been requested but not yet granted or confirmed.
+                           This is common for `dpv:Consent`, where the API Consumer has initiated a request for Consent capture, but the User has not yet completed the process. For example, this occurs when a notice prompting the User to Provide consent has been displayed, but they have not yet made a decision.
               - `REVOKED`: Where applicable (primarily for `dpv:Consent` and `dpv:LegitimateInterest`), the user has actively withdrawn their permission, or the previously valid `legalBasis` is no longer considered so due to user action.
                            This includes revocation of Consent or a successful objection (opt-out) to processing based on legitimate interest.
               - `EXPIRED`: Where applicable, the validity of the `legalBasis` for data processing has ceased due to the passage of time or a pre-defined condition.

--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -5,26 +5,28 @@ info:
 
     The Consent Info API allows an API Consumer to verify the Consent status of a particular User for that API Consumer (identified by `client_id` from the access token) concerning requested scope(s) and a specific Purpose. It helps determine if Consent is legally required for these parameters. If Consent is necessary but not yet granted, or if it has expired, the API can provide a URL pointing to the API Provider's Consent capture channel. This enables the API Consumer to direct the User to grant or renew Consent in a secure and trusted environment.
 
+    While verifying User Consent is a primary use case, this API allows to check the validity of *any* Legal Basis (e.g., `dpv:Consent`, `dpv:LegitimateInterest`, `dpv:Contract`, etc) that authorizes data processing for a given Purpose.
+
     # Introduction
 
-    The primary function of this API is to enable API Consumers to ascertain a User's Consent preferences before attempting to access or process their personal data via other APIs. By providing a standardized way to check Consent, this API facilitates compliance with privacy regulations and promotes transparency with users. Key inputs include the specific scope(s) of access being requested, the purpose for data processing, and an identifier for the User (either explicitly provided or derived from a three-legged access token). The API responds with the current Consent status, the applicable legal basis for data processing, and, if appropriate and requested, a URL for the User to manage their Consent.
+    The primary function of this API is to enable API Consumers to ascertain the authorization status for processing personal data before using other APIs. By providing a standardized way to check the validity of a legal basis, this API facilitates compliance with privacy regulations and promotes transparency with users. Key inputs include the specific scope(s) of access being requested, the Purpose for data processing, and an identifier for the User (either explicitly provided or derived from a three-legged access token). The API responds with the validity status of the applicable Legal Basis, and, if the Legal Basis is `dpv:Consent`, can provide a URL for the User to manage it.
 
     # Relevant terms and definitions
 
     * **Consent**: An explicit opt-in action that the User takes to allow processing of Personal Data. Consent grants the API Consumer access to a set of scopes related to the User for a specific Purpose.
     * **Purpose**: The reason for which Personal Data will be processed by an API Consumer. CAMARA defines a standard set of Purposes which can be used by API Consumers to specify the reason for their intended Personal Data processing.
     * **Scope**: A string representing the specific access rights or actions an API Consumer requests from the User for their data (e.g., "location-verification:verify"). A request can contain multiple scopes.
-    * **Legal Basis**: The justification under data protection law for processing personal data. This API uses terms from the W3C Data Privacy Vocabulary (DPV), such as `dpv:Consent`, `dpv:LegitimateInterest`, `dpv:Contract`, etc., to indicate the relevant legal ground.
+    * **Legal Basis**: The justification under data protection law for processing Personal Data. This API uses terms from the W3C Data Privacy Vocabulary (DPV), such as `dpv:Consent`, `dpv:LegitimateInterest`, `dpv:Contract`, etc., to indicate the relevant legal ground.
 
     # API Functionality
 
-    This API enables an API Consumer to determine whether user Consent (or another valid legal basis) is in place for the requested actions, based on the provided scope(s) and Purpose, and for the specific API Consumer making the request. NOTE: The response may contain multiple `consentInfo` array items, for instance, if the requested scopes pertain to different underlying services or require distinct legal assessments (e.g., some scopes rely on `dpv:Consent` while others rely on `dpv:LegitimateInterest`).
+    This API enables an API Consumer to determine whether user Consent (or another valid Legal Basis) is in place for the requested actions, based on the provided scope(s) and Purpose, and for the specific API Consumer making the request. NOTE: The response may contain multiple `consentInfo` array items, for instance, if the requested scopes pertain to different underlying services or require distinct legal assessments (e.g., some scopes rely on `dpv:Consent` while others rely on `dpv:LegitimateInterest`).
 
     Specifically, the API:
 
-    * Determines the need for Consent or other Legal Basis: Evaluates whether user Consent or another legal justification is necessary according to the specified parameters (scopes, Purpose, API Consumer) and relevant legal requirements.
-    * Provides the current Consent status and Legal Basis: If a legal basis is required, the API returns its current status (e.g., `READY`, `PENDING`, `REVOKED`, `EXPIRED`) and the specific type of `legalBasis` (e.g., `dpv:Consent`, `dpv:LegitimateInterest`).
-    * Offers a Consent Capture URL: If the API Consumer sets `requestCaptureUrl` to `true` in the request, and if the user needs to provide or renew Consent (e.g., the status is `PENDING` or `EXPIRED` for a `dpv:Consent` legal basis), the API supplies the API Provider's Consent capture URL.
+    * Indicates the applicable Legal Basis: Indicates which legal basis (e.g., `dpv:Consent`, `dpv:LegitimateInterest`) is required for the requested scopes, Purpose, and API Consumer according to relevant legal frameworks.
+    * Provides the data processing validity status and reason: If a legal basis is required, the API returns `statusValidForProcessing`, a boolean flag that is `true` if processing is permitted. If the flag is `false`, a `statusReason` field (with values like `PENDING`, `REVOKED`, `EXPIRED`) is also returned to explain why.
+    * Offers a Consent Capture URL: This functionality is specific to the `dpv:Consent` legal basis. If the API Consumer sets `requestCaptureUrl` to `true`, and if a user needs to provide or renew their Consent (e.g., the `statusReason` is `PENDING` or `EXPIRED`), the API supplies the API Provider's Consent capture URL.
 
     Importantly, this API does NOT delegate Consent capture to the API Consumer but rather empowers the API Consumer to present the API Provider's Consent capture URL at the most opportune time and place. The actual Consent capture occurs within the API Provider's secure environment, ensuring the User's authentication with the API Provider.
 
@@ -32,7 +34,7 @@ info:
 
     The "Camara Security and Interoperability Profile" provides details of how an API consumer requests an access token. Please refer to Identity and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the profile.
 
-    The specific authorization flows to be used will be agreed upon during the onboarding process, happening between the API consumer and the API provider, taking into account the declared purpose for accessing the API, whilst also being subject to the prevailing legal framework dictated by local legislation.
+    The specific authorization flows to be used will be agreed upon during the onboarding process, happening between the API consumer and the API provider, taking into account the declared Purpose for accessing the API, whilst also being subject to the prevailing legal framework dictated by local legislation.
 
     In cases where personal data is processed by the API and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of three-legged access tokens is mandatory. This ensures that the API remains in compliance with privacy regulations, upholding the principles of transparency and user-centric privacy-by-design.
 
@@ -65,20 +67,20 @@ servers:
         default: http://localhost:9091
         description: API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath`
 tags:
-  - name: Verify Consent Status
-    description: Create a request to verify the Consent status
+  - name: Verify Status
+    description: Create a request to verify the Consent (or other Legal Basis) status
 paths:
   /verify:
     post:
-      summary: Create a request to verify the Consent status
+      summary: Create a request to verify the Consent (or other Legal Basis) status
       description: |
-        Create a request to verify the Consent status of a specific User to the API Consumer for the requested scope(s) and Purpose. The API Consumer is identified by the `client_id` parameter deduced from the access token.
+        Create a request to verify the Consent (or other Legal Basis) status of a specific User to the API Consumer for the requested scope(s) and Purpose. The API Consumer is identified by the `client_id` parameter deduced from the access token.
       operationId: verifyConsentStatus
       security:
         - openId:
             - consent-info:verify
       tags:
-        - Verify Consent Status
+        - Verify Status
       parameters:
         - $ref: '#/components/parameters/x-correlator'
       requestBody:
@@ -146,7 +148,7 @@ paths:
                           - "number-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
                         legalBasis: "dpv:LegitimateInterest"
-                        status: READY
+                        statusValidForProcessing: true
                 CONSENT_REQUIRED:
                   summary: Consent is required
                   description: |
@@ -157,7 +159,8 @@ paths:
                           - "location-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
                         legalBasis: "dpv:Consent"
-                        status: PENDING
+                        statusValidForProcessing: false
+                        statusReason: PENDING
                 CONSENT_REQUIRED_CAPTURE_URL:
                   summary: Consent is required and capture URL is provided
                   description: |
@@ -168,7 +171,8 @@ paths:
                           - "location-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
                         legalBasis: "dpv:Consent"
-                        status: EXPIRED
+                        statusValidForProcessing: false
+                        statusReason: EXPIRED
                         expirationDate: '2023-07-03T14:27:08.312+02:00'
                     captureUrl: 'https://example.org/consent-capture-url'
                 CONSENT_REVOKED:
@@ -181,7 +185,8 @@ paths:
                           - "location-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
                         legalBasis: "dpv:Consent"
-                        status: REVOKED
+                        statusValidForProcessing: false
+                        statusReason: REVOKED
                 LEGITIMATE_INTEREST_OPT_OUT:
                   summary: Legitimate interest opt-out
                   description: |
@@ -192,7 +197,8 @@ paths:
                           - "number-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
                         legalBasis: "dpv:LegitimateInterest"
-                        status: REVOKED
+                        statusValidForProcessing: false
+                        statusReason: REVOKED
                 MULTIPLE_SCOPES_ONE_API:
                   summary: Multiple scopes for one API
                   description: |
@@ -207,7 +213,7 @@ paths:
                           - "quality-on-demand:sessions:retrieve-by-device"
                         purpose: "dpv:RequestedServiceProvision"
                         legalBasis: "dpv:Contract"
-                        status: READY
+                        statusValidForProcessing: true
                 MULTIPLE_SCOPES_MULTIPLE_APIS:
                   summary: Multiple scopes for multiple APIs
                   description: |
@@ -218,12 +224,14 @@ paths:
                           - "location-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
                         legalBasis: "dpv:Consent"
-                        status: PENDING
+                        statusValidForProcessing: false
+                        statusReason: PENDING
                       - scopes:
                           - "device-roaming-status:read"
                         purpose: "dpv:FraudPreventionAndDetection"
                         legalBasis: "dpv:Consent"
-                        status: PENDING
+                        statusValidForProcessing: false
+                        statusReason: PENDING
                     captureUrl: 'https://example.org/consent-capture-url'
                 MULTIPLES_SCOPES_ONE_API_DIFFERENT_STATUS:
                   summary: Multiple scopes for one API with different status
@@ -235,12 +243,13 @@ paths:
                           - "sim-swap:check"
                         purpose: "dpv:FraudPreventionAndDetection"
                         legalBasis: "dpv:LegitimateInterest"
-                        status: READY
+                        statusValidForProcessing: true
                       - scopes:
                           - "sim-swap:retrieve-date"
                         purpose: "dpv:FraudPreventionAndDetection"
                         legalBasis: "dpv:LegitimateInterest"
-                        status: REVOKED
+                        statusValidForProcessing: false
+                        statusReason: REVOKED
         "400":
           $ref: "#/components/responses/Generic400"
         "401":
@@ -320,12 +329,13 @@ components:
           type: string
           format: url
           description: |
-            URL where the User can provide the necessary Consent. This field is only present if requested by the API Consumer and if `consentInfo[*].legalBasis` is `dpv:Consent` and its `consentInfo[*].status` is `PENDING` or `EXPIRED`.
+            URL where the User can provide the necessary Consent. This field is only present if requested by the API Consumer and if `consentInfo[*].legalBasis` is `dpv:Consent`, `consentInfo[*].statusValidForProcessing` is `false`, and `consentInfo[*].statusReason` is `PENDING` or `EXPIRED`.
           example: 'https://example.org/consent-capture-url'
     consentInfo:
       type: array
       description: |
-        The consentInfo contains the information about the Consent status for the requested scope(s) and Purpose. It may be required more than one array item for the requested scope(s) and Purpose, e.g. when the requested scopes are related to multiple APIs.
+        Provides information about the data processing validity status for the requested scope(s) and Purpose. It contains details about the applicable Legal Basis, whether it is currently valid for processing data, and if not, the reason why it is not valid. This information helps API Consumers understand the current state of Consent or other Leal Basis for processing data.
+        It may be required more than one array item for the requested scope(s) and Purpose, e.g. when the requested scopes are related to multiple APIs.
       items:
         $ref: "#/components/schemas/consentInfoObject"
       minItems: 1
@@ -335,7 +345,7 @@ components:
         - scopes
         - purpose
         - legalBasis
-        - status
+        - statusValidForProcessing
       properties:
         scopes:
           $ref: "#/components/schemas/Scopes"
@@ -344,7 +354,7 @@ components:
         legalBasis:
           type: string
           description: |
-              The applicable legal basis for the requested scope(s) and Purpose. It uses terms from the W3C [Data Privacy Vocabulary](https://w3c.github.io/dpv/2.1/) (DPV).
+              The applicable Legal Basis for the requested scope(s) and Purpose. It uses terms from the W3C [Data Privacy Vocabulary](https://w3c.github.io/dpv/2.1/) (DPV).
           enum:
             - dpv:Consent
             - dpv:LegitimateInterest
@@ -352,31 +362,34 @@ components:
             - dpv:LegalObligation
             - dpv:PublicInterest
             - dpv:VitalInterest
-        status:
+        statusValidForProcessing:
+          type: boolean
+          description: |
+              Boolean flag that shows whether the specified Legal Basis is currently valid for processing data related to the indicated scope(s) and Purpose.
+              * `true` - The specified `legalBasis` is currently valid and permits the requested data processing. For example, necessary user Consent has been obtained; a legitimate interests assessment resulted in a positive outcome, with no overriding objections; or the processing is deemed necessary under an existing contract.
+              * `false` - The specified `legalBasis` is not valid for processing the requested scope(s) and Purpose. The reason for this is indicated in the `statusReason` field. This may be because the User has not yet provided Consent, has opted out of processing based on legitimate interest or because the Legal Basis is no longer applicable for other reasons.
+        statusReason:
           type: string
           enum:
             - PENDING
-            - READY
             - REVOKED
             - EXPIRED
           description: |
-              Shows the current validity of the specified `legalBasis` for processing data related to the indicated scope(s) and Purpose.
-              It signals if processing is currently allowed and offers a general indication if it is not, if its validity is time-bound, or if it has ceased.
+              This field must be present if `statusValidForProcessing` is `false`. It indicates the reason why the specified `legalBasis` is not valid for processing the requested scope(s) and Purpose. It provides API consumers with additional context on the current state of the Legal Basis, helping them to understand its applicability and the next steps they may need to take.
+              It is particularly useful for determining whether the API Consumer should prompt the User to take action, such as providing Consent or renewing an existing Consent.
               Possible values are:
               - `PENDING`: The specified `legalBasis` is not yet established or fully validated for the requested data processing.
-                           For example, the user has not yet provided Consent under `dpv:Consent` legal basis.
-              - `READY`: The specified `legalBasis` is currently valid and permits the requested data processing.
-                         For example, necessary user Consent has been obtained, a legitimate interests assessment resulted in a positive outcome without overriding objections, or the processing is deemed necessary under an existing contract.
+                           For example, the user has not yet provided Consent under `dpv:Consent` Legal Basis.
               - `REVOKED`: Where applicable (primarily for `dpv:Consent` and `dpv:LegitimateInterest`), the user has actively withdrawn their permission, or the previously valid `legalBasis` is no longer considered so due to user action.
                            This includes revocation of Consent or a successful objection (opt-out) to processing based on legitimate interest.
               - `EXPIRED`: Where applicable, the validity of the `legalBasis` for data processing has ceased due to the passage of time or a pre-defined condition.
-                           This is common for time-limited Consents or could apply to other bases if their applicability was time-bound.
+                           This is common for time-limited Consents or could apply to other Legal Basis if their applicability was time-bound.
         expirationDate:
           type: string
           format: date-time
           description: |
              The date and time at which the validity of this `legalBasis` is set to expire or has expired.
-             It applies mainly to time-limited legal bases, such as `dpv:Consent`, or others where a specific duration of validity is defined. This field is only present if `status` is `READY` (indicating a future expiration if applicable) or `EXPIRED` (indicating the past expiration date). It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone. Recommended format is yyyy-MM-dd'T'HH:mm:ss.SSSZ (i.e. which allows 2023-07-03T14:27:08.312+02:00 or 2023-07-03T12:27:08.312Z).
+             It applies mainly to time-limited Legal Basis, such as `dpv:Consent`, or others where a specific duration of validity is defined. This field is only applicable if `statusValidForProcessing` is `true` (indicating a future expiration) or if `statusValidForProcessing` is `false` and `statusReason` is `EXPIRED` (indicating the past expiration date). It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone. Recommended format is yyyy-MM-dd'T'HH:mm:ss.SSSZ (i.e. which allows 2023-07-03T14:27:08.312+02:00 or 2023-07-03T12:27:08.312Z).
           example: '2023-07-03T14:27:08.312+02:00'
     ErrorInfo:
       type: object

--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -481,7 +481,7 @@ components:
                   code:
                     enum:
                       - PERMISSION_DENIED
-                      - CONSENT_INFO.NOT_ALLOWED_SCOPES
+                      - CONSENT_INFO.NOT_ALLOWED_SCOPES_PURPOSE
                       - CONSENT_INFO.CAPTURE_FREQUENCY_EXCEEDED
           examples:
             GENERIC_403_PERMISSION_DENIED:
@@ -490,11 +490,11 @@ components:
                 status: 403
                 code: PERMISSION_DENIED
                 message: Client does not have sufficient permissions to perform this action.
-            NOT_ALLOWED_SCOPES:
+            NOT_ALLOWED_SCOPES_PURPOSE:
               description: The requested scope(s) and Purpose combination is not allowed for the API Consumer, e.g. the API Consumer has not onboarded the appropriate API(s) with the API Provider for the declared Purpose.
               value:
                 status: 403
-                code: CONSENT_INFO.NOT_ALLOWED_SCOPES
+                code: CONSENT_INFO.NOT_ALLOWED_SCOPES_PURPOSE
                 message: The requested scope(s) and Purpose combination is not allowed for this API Consumer.
             CAPTURE_FREQUENCY_EXCEEDED:
               description: The frequency of consent capture requests has been exceeded.

--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -16,7 +16,7 @@ info:
 
     # API Functionality
 
-    This API enables the API Consumer making the request to determine whether its data processing is permitted for a given User, scope(s) and Purpose.
+    This API enables the API Consumer to determine whether their data processing is permitted for a given User, scope(s) and Purpose.
 
     Specifically, the API:
 

--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -7,7 +7,7 @@ info:
 
     # Introduction
 
-    The primary function of this API is to enable API Consumers to ascertain a User's consent preferences before attempting to access or process their personal data via other APIs. By providing a standardized way to check consent, this API facilitates compliance with privacy regulations and promotes transparency with the User. Key inputs include the specific scope(s) of access being requested, the purpose for data processing, and an identifier for the User (either explicitly provided or derived from a three-legged access token). The API responds with the current consent status, the applicable legal basis for data processing, and, if appropriate and requested, a URL for the User to manage their consent.
+    The primary function of this API is to enable API Consumers to ascertain a User's consent preferences before attempting to access or process their personal data via other APIs. By providing a standardized way to check consent, this API facilitates compliance with privacy regulations and promotes transparency with users. Key inputs include the specific scope(s) of access being requested, the purpose for data processing, and an identifier for the User (either explicitly provided or derived from a three-legged access token). The API responds with the current consent status, the applicable legal basis for data processing, and, if appropriate and requested, a URL for the User to manage their consent.
 
     # Relevant terms and definitions
 

--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -20,7 +20,7 @@ info:
 
     # API Functionality
 
-    This API enables an API Consumer to determine whether user Consent (or another valid Legal Basis) is in place for the requested actions, based on the provided scope(s) and Purpose, and for the specific API Consumer making the request. NOTE: The response may contain multiple `consentInfo` array items, for instance, if the requested scopes pertain to different underlying services or require distinct legal assessments (e.g., some scopes rely on `dpv:Consent` while others rely on `dpv:LegitimateInterest`).
+    This API enables an API Consumer to determine whether user Consent (or another valid Legal Basis) is in place for the requested actions, based on the provided scope(s) and Purpose, and for the specific API Consumer making the request. NOTE: The response may contain multiple array items, for instance, if the requested scopes pertain to different underlying services or require distinct legal assessments (e.g., some scopes rely on `dpv:Consent` while others rely on `dpv:LegitimateInterest`).
 
     Specifically, the API:
 
@@ -143,7 +143,7 @@ paths:
                   description: |
                     Data processing is allowed for the requested scope(s) and Purpose.
                   value:
-                    consentInfo:
+                    statusInfo:
                       - scopes:
                           - "number-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
@@ -154,7 +154,7 @@ paths:
                   description: |
                     Consent is required for the requested scope(s) and Purpose
                   value:
-                    consentInfo:
+                    statusInfo:
                       - scopes:
                           - "location-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
@@ -166,7 +166,7 @@ paths:
                   description: |
                     Consent is required for the requested scope(s) and Purpose but it is not provided by the User. The API Provider provides a Consent capture URL.
                   value:
-                    consentInfo:
+                    statusInfo:
                       - scopes:
                           - "location-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
@@ -180,7 +180,7 @@ paths:
                   description: |
                     Consent is revoked for the requested scope(s) and Purpose.
                   value:
-                    consentInfo:
+                    statusInfo:
                       - scopes:
                           - "location-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
@@ -192,7 +192,7 @@ paths:
                   description: |
                     The User has opted out of the legitimate interest for the requested scope(s) and Purpose.
                   value:
-                    consentInfo:
+                    statusInfo:
                       - scopes:
                           - "number-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
@@ -204,7 +204,7 @@ paths:
                   description: |
                     Request with multiple scopes corresponding to one API.
                   value:
-                    consentInfo:
+                    statusInfo:
                       - scopes:
                           - "quality-on-demand:sessions:create"
                           - "quality-on-demand:sessions:read"
@@ -219,7 +219,7 @@ paths:
                   description: |
                     Request with multiple scopes corresponding to multiple APIs.
                   value:
-                    consentInfo:
+                    statusInfo:
                       - scopes:
                           - "location-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
@@ -238,7 +238,7 @@ paths:
                   description: |
                     Request with multiple scopes corresponding to one API. Different status for each scope.
                   value:
-                    consentInfo:
+                    statusInfo:
                       - scopes:
                           - "sim-swap:check"
                         purpose: "dpv:FraudPreventionAndDetection"
@@ -321,17 +321,17 @@ components:
     VerifyConsentStatusResponseBody:
       type: object
       required:
-        - consentInfo
+        - statusInfo
       properties:
-        consentInfo:
-          $ref: "#/components/schemas/consentInfo"
+        statusInfo:
+          $ref: "#/components/schemas/statusInfo"
         captureUrl:
           type: string
           format: url
           description: |
-            URL where the User can provide the necessary Consent. This field is only present if requested by the API Consumer and if `consentInfo[*].legalBasis` is `dpv:Consent`, `consentInfo[*].statusValidForProcessing` is `false`, and `consentInfo[*].statusReason` is `PENDING` or `EXPIRED`.
+            URL where the User can provide the necessary Consent. This field is only present if requested by the API Consumer and if `statusInfo[*].legalBasis` is `dpv:Consent`, `statusInfo[*].statusValidForProcessing` is `false`, and `statusInfo[*].statusReason` is `PENDING` or `EXPIRED`.
           example: 'https://example.org/consent-capture-url'
-    consentInfo:
+    statusInfo:
       type: array
       description: |
         Provides information about the data processing validity status for the requested scope(s) and Purpose. It contains details about the applicable Legal Basis, whether it is currently valid for processing data, and if not, the reason why it is not valid. This information helps API Consumers understand the current state of Consent or other Leal Basis for processing data.

--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -2,35 +2,29 @@ openapi: 3.0.3
 info:
   title: Consent Info API
   description: |
-
-    The Consent Info API allows an API Consumer to verify the Consent status of a particular User for that API Consumer (identified by `client_id` from the access token) concerning requested scope(s) and a specific Purpose. It helps determine if Consent is legally required for these parameters. If Consent is necessary but not yet granted, or if it has expired, the API can provide a URL pointing to the API Provider's Consent capture channel. This enables the API Consumer to direct the User to grant or renew Consent in a secure and trusted environment.
-
-    While verifying User Consent is a primary use case, this API allows to check the validity of *any* Legal Basis (e.g., `dpv:Consent`, `dpv:LegitimateInterest`, `dpv:Contract`, etc) that authorizes data processing for a given Purpose.
+    The Consent Info API allows API Consumers to easily validate whether they have the necessary permissions to process User's personal data for a specific Purpose before using other CAMARA APIs. It provides a simple `true`/`false` response and, where applicable, a URL to direct the User to manage their Consent.
 
     # Introduction
 
-    The primary function of this API is to enable API Consumers to ascertain the authorization status for processing personal data before using other APIs. By providing a standardized way to check the validity of a legal basis, this API facilitates compliance with privacy regulations and promotes transparency with users. Key inputs include the specific scope(s) of access being requested, the Purpose for data processing, and an identifier for the User (either explicitly provided or derived from a three-legged access token). The API responds with the validity status of the applicable Legal Basis, and, if the Legal Basis is `dpv:Consent`, can provide a URL for the API Consumer to manage it.
+    This API facilitates compliance with privacy regulations and promotes transparency with Users by providing a standardized way to check whether, for example, the User has given their Consent or opted out of data processing. Key inputs include the specific scope(s) of access being requested (i.e. the CAMARA API(s) operations to which the data processing refers), the Purpose for data processing, and a User identifier (either explicitly provided or derived from a three-legged access token). The API responds with the validity status of the data processing, and, where applicable, can provide a capture URL for the API Consumer to manage it.
 
     # Relevant terms and definitions
 
-    * **Consent**: An explicit opt-in action that the User takes to allow processing of Personal Data. Consent grants the API Consumer access to a set of scopes related to the User for a specific Purpose.
-    * **Purpose**: The reason for which Personal Data will be processed by an API Consumer. CAMARA defines a standard set of Purposes which can be used by API Consumers to specify the reason for their intended Personal Data processing.
+    * **Consent**: An explicit opt-in action that the User takes to allow processing of personal data. Consent grants the API Consumer access to a set of scopes related to the User for a specific Purpose.
+    * **Purpose**: The reason for which personal data will be processed by an API Consumer. CAMARA defines a standard set of Purposes which can be used by API Consumers to specify the reason for their intended personal data processing. CAMARA uses the [W3C Data Privacy Vocabulary](https://w3c.github.io/dpv/2.0/dpv/) (DPV) to represent these purposes e.g. `dpv:FraudPreventionAndDetection` or `dpv:RequestedServiceProvision`.
     * **Scope**: A string representing the specific access rights or actions an API Consumer requests from the User for their data (e.g., "location-verification:verify"). A request can contain multiple scopes.
-    * **Legal Basis**: The justification under data protection law for processing Personal Data. It identifies the lawful ground on which the API Consumer relies (e.g., Consent, Contract, Legitimate Interest).
-
-    This API adopts the [W3C Data Privacy Vocabulary](https://w3c.github.io/dpv/2.0/dpv/) (DPV) to represent both Purpose and Legal Basis. For example, Legal Basis include values such as `dpv:Consent` or `dpv:LegitimateInterest`, while Purposes include `dpv:FraudPreventionAndDetection` or `dpv:RequestedServiceProvision`.
 
     # API Functionality
 
-    This API enables an API Consumer to determine whether user Consent (or another valid Legal Basis) is in place for the requested actions, based on the provided scope(s) and Purpose, and for the specific API Consumer making the request. NOTE: The response may contain multiple array items, for instance, if the requested scopes pertain to different underlying services or require distinct legal assessments (e.g., some scopes rely on `dpv:Consent` while others rely on `dpv:LegitimateInterest`).
+    This API enables an API Consumer to determine whether the status of data processing is valid or not for a given User, based on the provided scope(s) and Purpose, as well as the API Consumer making the request.
 
     Specifically, the API:
 
-    * Indicates the applicable Legal Basis: Indicates which legal basis (e.g., `dpv:Consent`, `dpv:LegitimateInterest`) is required for the requested scopes, Purpose, and API Consumer according to relevant legal frameworks.
-    * Provides the data processing validity status and reason: The API returns `statusValidForProcessing`, a boolean flag that is `true` if processing is permitted. If the flag is `false`, a `statusReason` field is also returned to explain why.
-    * Offers a Consent Capture URL: This functionality is specific to the `dpv:Consent` legal basis. If the API Consumer sets `requestCaptureUrl` to `true`, and if a user needs to provide or renew their Consent, the API supplies the API Provider's Consent capture URL.
+    * **Provides the data processing validity status**: The API returns `statusValidForProcessing`, a boolean flag that indicates whether the requested data processing is currently permitted (`true`) or not (`false`).
+    * **Provides an explanation if invalid**: If data processing is not permitted, the response includes a `statusReason` field to explain why.
+    * **Offers a Capture URL (if requested)**: If the status is not valid because user action is required, and the API Consumer sets `requestCaptureUrl` to `true`, the API will return a `captureUrl` field that can be presented to the User. This URL directs them to the API Provider's secure Consent capture channel, where they can provide or renew their Consent.
 
-    Importantly, this API does NOT delegate Consent capture to the API Consumer but rather empowers the API Consumer to present the API Provider's Consent capture URL at the most opportune time and place. The actual Consent capture occurs within the API Provider's secure environment, ensuring the User's authentication with the API Provider.
+    **Importantly, this API does NOT delegate Consent capture to the API Consumer but rather empowers the API Consumer to present the API Provider's Consent capture URL at the most opportune time and place. The actual Consent capture occurs within the API Provider's secure environment, ensuring the User's authentication with the API Provider.**
 
     # Authorization and authentication
 
@@ -63,36 +57,35 @@ info:
   version: wip
   x-camara-commonalities: 0.5
 servers:
-  - url: '{apiRoot}/consent-info/vwip'
+  - url: "{apiRoot}/consent-info/vwip"
     variables:
       apiRoot:
         default: http://localhost:9091
         description: API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath`
 tags:
-  - name: Verify Status
-    description: Create a request to verify the status of Consent or other Legal Basis
+  - name: Retrieve Status
+    description: Create a request to retrieve the validity status of the data processing
 paths:
-  /verify:
+  /retrieve:
     post:
-      summary: Create a request to verify the status of Consent or other Legal Basis
+      summary: Create a request to retrieve the validity status of the data processing
       description: |
-        Create a request to verify the Consent or other Legal Basis of a specific User to the API Consumer for the requested scope(s) and Purpose. The API Consumer is identified by the `client_id` parameter deduced from the access token.
-      operationId: verifyStatus
+        Create a request to retrieve the validity status of data processing for a given User, based on the provided scope(s) and Purpose, as well as the API Consumer making the request. The API Consumer is identified by the `client_id` parameter deduced from the access token.
+      operationId: retrieveStatus
       security:
         - openId:
-            - consent-info:verify
+            - consent-info:retrieve
       tags:
-        - Verify Status
+        - Retrieve Status
       parameters:
-        - $ref: '#/components/parameters/x-correlator'
+        - $ref: "#/components/parameters/x-correlator"
       requestBody:
         required: true
-        description:
-          Status verification request
+        description: Retrieve status request
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/VerifyStatusRequestBody"
+              $ref: "#/components/schemas/RetrieveStatusRequestBody"
             examples:
               ONE_SCOPE_ONE_API:
                 summary: One scope
@@ -134,11 +127,11 @@ paths:
           description: OK
           headers:
             x-correlator:
-              $ref: '#/components/headers/x-correlator'
+              $ref: "#/components/headers/x-correlator"
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/VerifyStatusResponseBody"
+                $ref: "#/components/schemas/RetrieveStatusResponseBody"
               examples:
                 READY_FOR_PROCESSING:
                   summary: Ready for processing
@@ -149,7 +142,6 @@ paths:
                       - scopes:
                           - "number-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
-                        legalBasis: "dpv:LegitimateInterest"
                         statusValidForProcessing: true
                 CONSENT_REQUIRED:
                   summary: Consent is required
@@ -160,23 +152,21 @@ paths:
                       - scopes:
                           - "location-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
-                        legalBasis: "dpv:Consent"
                         statusValidForProcessing: false
                         statusReason: REQUESTED
                 CONSENT_REQUIRED_CAPTURE_URL:
                   summary: Consent is required and capture URL is provided
                   description: |
-                    Consent is required for the requested scope(s) and Purpose but it is not provided by the User. The API Provider provides a Consent capture URL.
+                    Consent is required for the requested scope(s) and Purpose but it is expired. The API Provider provides a Consent capture URL.
                   value:
                     statusInfo:
                       - scopes:
                           - "location-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
-                        legalBasis: "dpv:Consent"
                         statusValidForProcessing: false
                         statusReason: EXPIRED
-                        expirationDate: '2023-07-03T14:27:08.312+02:00'
-                    captureUrl: 'https://example.org/consent-capture-url'
+                        expirationDate: "2023-07-03T14:27:08.312+02:00"
+                    captureUrl: "https://example.org/consent-capture-url"
                 CONSENT_REVOKED:
                   summary: Consent is revoked
                   description: |
@@ -186,21 +176,19 @@ paths:
                       - scopes:
                           - "location-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
-                        legalBasis: "dpv:Consent"
                         statusValidForProcessing: false
                         statusReason: REVOKED
-                LEGITIMATE_INTEREST_OPT_OUT:
-                  summary: Legitimate interest opt-out
+                DATA_PROCESSING_OPT_OUT:
+                  summary: Data processing opt-out
                   description: |
-                    The User has opted out of the legitimate interest for the requested scope(s) and Purpose.
+                    The User has opted out of the data processing for the requested scope(s) and Purpose.
                   value:
                     statusInfo:
                       - scopes:
                           - "number-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
-                        legalBasis: "dpv:LegitimateInterest"
                         statusValidForProcessing: false
-                        statusReason: REVOKED
+                        statusReason: OBJECTED
                 MULTIPLE_SCOPES_ONE_API:
                   summary: Multiple scopes for one API
                   description: |
@@ -214,7 +202,6 @@ paths:
                           - "quality-on-demand:sessions:delete"
                           - "quality-on-demand:sessions:retrieve-by-device"
                         purpose: "dpv:RequestedServiceProvision"
-                        legalBasis: "dpv:Contract"
                         statusValidForProcessing: true
                 MULTIPLE_SCOPES_MULTIPLE_APIS:
                   summary: Multiple scopes for multiple APIs
@@ -225,16 +212,14 @@ paths:
                       - scopes:
                           - "location-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
-                        legalBasis: "dpv:Consent"
                         statusValidForProcessing: false
                         statusReason: PENDING
                       - scopes:
                           - "device-roaming-status:read"
                         purpose: "dpv:FraudPreventionAndDetection"
-                        legalBasis: "dpv:Consent"
                         statusValidForProcessing: false
                         statusReason: PENDING
-                    captureUrl: 'https://example.org/consent-capture-url'
+                    captureUrl: "https://example.org/consent-capture-url"
                 MULTIPLES_SCOPES_ONE_API_DIFFERENT_STATUS:
                   summary: Multiple scopes for one API with different status
                   description: |
@@ -244,20 +229,18 @@ paths:
                       - scopes:
                           - "sim-swap:check"
                         purpose: "dpv:FraudPreventionAndDetection"
-                        legalBasis: "dpv:LegitimateInterest"
                         statusValidForProcessing: true
                       - scopes:
                           - "sim-swap:retrieve-date"
                         purpose: "dpv:FraudPreventionAndDetection"
-                        legalBasis: "dpv:LegitimateInterest"
                         statusValidForProcessing: false
-                        statusReason: REVOKED
+                        statusReason: OBJECTED
         "400":
           $ref: "#/components/responses/Generic400"
         "401":
           $ref: "#/components/responses/Generic401"
         "403":
-          $ref: "#/components/responses/verifyConsentStatus403"
+          $ref: "#/components/responses/retrieveStatus403"
         "404":
           $ref: "#/components/responses/Generic404"
         "422":
@@ -284,10 +267,10 @@ components:
       description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, prefixed with '+'.
       pattern: '^\+[1-9][0-9]{4,14}$'
       example: "+123456789"
-    VerifyStatusRequestBody:
+    RetrieveStatusRequestBody:
       type: object
       description: |
-        The request body for the status verification request. It contains the requested scope(s), the Purpose for which the API Consumer intends to process the User's Personal Data, a flag indicating whether the API Consumer requests a Consent capture URL and optionally the phone number of the User. The phone number is required when the API is invoked using a two-legged access token, but MUST NOT be provided when a three-legged access token is used, as the subject will be uniquely identified from the access token.
+        The request body for the retrieve status request. It contains the requested scope(s), the Purpose for which the API Consumer intends to process the User's personal data, a flag indicating whether the API Consumer requests a Consent capture URL and optionally the phone number of the User. The phone number is required when the API is invoked using a two-legged access token, but MUST NOT be provided when a three-legged access token is used, as the subject will be uniquely identified from the access token.
       required:
         - scopes
         - purpose
@@ -317,10 +300,11 @@ components:
         - "location-verification:verify"
     Purpose:
       type: string
+      pattern: '^dpv:[a-zA-Z0-9]+$'
       description: |
-        The reason for which Personal Data will be processed by the API Consumer. CAMARA defines a standard set of Purposes which can be used by API Consumers to specify the reason for their intended Personal Data processing.
+        The reason for which personal data will be processed by the API Consumer. CAMARA defines a standard set of Purposes which can be used by API Consumers to specify the reason for their intended personal data processing. CAMARA uses the [W3C Data Privacy Vocabulary](https://w3c.github.io/dpv/2.0/dpv/) (DPV) to represent these purposes e.g. `dpv:FraudPreventionAndDetection` or `dpv:RequestedServiceProvision`.
       example: "dpv:FraudPreventionAndDetection"
-    VerifyStatusResponseBody:
+    RetrieveStatusResponseBody:
       type: object
       required:
         - statusInfo
@@ -331,13 +315,19 @@ components:
           type: string
           format: url
           description: |
-            URL where the User can provide the necessary Consent. This field is only present if requested by the API Consumer and if `statusInfo[*].legalBasis` is `dpv:Consent`, `statusInfo[*].statusValidForProcessing` is `false`, and `statusInfo[*].statusReason` is `PENDING`, `REQUESTED` or `EXPIRED`.
-          example: 'https://example.org/consent-capture-url'
+            URL where the User can provide the necessary Consent. This field is only present in the API response if the API Consumer requests it and if the following conditions are met:
+
+            - `statusInfo[*].statusValidForProcessing` is `false`, and
+            - `statusInfo[*].statusReason` is `PENDING`, `REQUESTED` or `EXPIRED`. 
+
+            Please note that this field is only applicable when the User Consent is required to enable valid data processing. A unique URL is provided to authorise all items in the statusInfo list that require user action.
+          example: "https://example.org/consent-capture-url"
     statusInfo:
       type: array
       description: |
-        Provides information about the data processing validity status for the requested scope(s) and Purpose. It contains details about the applicable Legal Basis, whether it is currently valid for processing data, and if not, the reason why it is not valid. This information helps API Consumers understand the current state of Consent or other Leal Basis for processing data.
-        It may be required more than one array item for the requested scope(s) and Purpose, e.g. when the requested scopes are related to multiple APIs.
+        Provides information about the validity status of the requested data processing for the specified scope(s) and Purpose. It contains details of whether the processing of the data is currently valid and, if not, the reason why. The expiration date of the validity may be also provided if applicable.
+
+        More than one array item may be required for the requested scope(s) and Purpose, e.g. when the requested scopes relate to multiple APIs.
       items:
         $ref: "#/components/schemas/statusInfoObject"
       minItems: 1
@@ -346,30 +336,18 @@ components:
       required:
         - scopes
         - purpose
-        - legalBasis
         - statusValidForProcessing
       properties:
         scopes:
           $ref: "#/components/schemas/Scopes"
         purpose:
           $ref: "#/components/schemas/Purpose"
-        legalBasis:
-          type: string
-          description: |
-              The applicable Legal Basis for the requested scope(s) and Purpose. It uses terms from the W3C [Data Privacy Vocabulary](https://w3c.github.io/dpv/2.1/) (DPV).
-          enum:
-            - dpv:Consent
-            - dpv:LegitimateInterest
-            - dpv:Contract
-            - dpv:LegalObligation
-            - dpv:PublicInterest
-            - dpv:VitalInterest
         statusValidForProcessing:
           type: boolean
           description: |
-              Boolean flag that shows whether the specified Legal Basis is currently valid for processing data related to the indicated scope(s) and Purpose.
-              * `true` - The specified `legalBasis` is currently valid and permits the requested data processing. For example, necessary user Consent has been obtained; a legitimate interests assessment resulted in a positive outcome, with no overriding objections; or the processing is deemed necessary under an existing contract.
-              * `false` - The specified `legalBasis` is not valid for processing the requested scope(s) and Purpose. The reason for this is indicated in the `statusReason` field. This may be because the User has not yet provided Consent, has opted out of processing based on legitimate interest or because the Legal Basis is no longer applicable for other reasons.
+            Boolean flag that shows the validity status of the requested data processing for the specified scope(s) and Purpose.
+            * `true` - indicates that the current status is valid and permits the requested data processing.
+            * `false` - indicates that the requested data processing is not permitted. The reason for this is provided in the `statusReason` field.
         statusReason:
           type: string
           enum:
@@ -377,25 +355,36 @@ components:
             - REQUESTED
             - REVOKED
             - EXPIRED
+            - OBJECTED
           description: |
-              This field must be present if `statusValidForProcessing` is `false`. It indicates the reason why the specified `legalBasis` is not valid for processing the requested scope(s) and Purpose. It provides API consumers with additional context on the current state of the Legal Basis, helping them to understand its applicability and the next steps they may need to take.
-              It is particularly useful for determining whether the API Consumer should prompt the User to take action, such as providing Consent or renewing an existing Consent.
-              Possible values are:
-              - `PENDING`: The specified `legalBasis` is not yet established or fully validated for the requested data processing.
-                           For example, the user has not yet provided Consent under `dpv:Consent` Legal Basis.
-              - `REQUESTED`: Where applicable, the specified `legalBasis` has been requested but not yet granted or confirmed.
-                           This is common for `dpv:Consent`, where the API Consumer has initiated a request for Consent capture, but the User has not yet completed the process. For example, this occurs when a notice prompting the User to Provide consent has been displayed, but they have not yet made a decision.
-              - `REVOKED`: Where applicable (primarily for `dpv:Consent` and `dpv:LegitimateInterest`), the user has actively withdrawn their permission, or the previously valid `legalBasis` is no longer considered so due to user action.
-                           This includes revocation of Consent or a successful objection (opt-out) to processing based on legitimate interest.
-              - `EXPIRED`: Where applicable, the validity of the `legalBasis` for data processing has ceased due to the passage of time or a pre-defined condition.
-                           This is common for time-limited Consents or could apply to other Legal Basis if their applicability was time-bound.
+            This field must be present if `statusValidForProcessing` is `false`. It indicates the reason why the requested data processing is not permitted for the specified scope(s) and Purpose. It provides API Consumers with additional context on the current validity status, helping them to understand its applicability and the next steps they may need to take.
+              
+            It is particularly useful for determining whether the API Consumer should prompt the User to take action, such as providing Consent or renewing an existing Consent.
+              
+            Possible values are:
+
+            - `PENDING`: The requested data processing has not yet been established or fully validated under the applicable privacy regulations.
+                        For example, the User has not yet provided Consent when it is required.
+            - `REQUESTED`: The permission for the requested data processing has been submitted but has not yet been granted or confirmed.
+                        This is common when the API Consumer has initiated a request for Consent capture, but the User has not yet completed the process. For example, this occurs when a notice prompting the User to provide Consent has been displayed, but they have not yet made a decision.
+            - `REVOKED`: The User has actively withdrawn their permission for the requested data processing after previously opting in.
+                        For example, the User revokes their Consent for the data processing.
+            - `OBJECTED`: The user has opted out of the requested data processing, despite a previous explicit opt-in not being required.
+                        This is common when the User has exercised their right to object to data processing under the applicable privacy regulations.
+            - `EXPIRED`: Where applicable, the validity of the data processing has ceased due to the passage of time or a pre-defined condition.
+                        This is common for time-limited Consents.
         expirationDate:
           type: string
           format: date-time
           description: |
-             The date and time at which the validity of this `legalBasis` is set to expire or has expired.
-             It applies mainly to time-limited Legal Basis, such as `dpv:Consent`, or others where a specific duration of validity is defined. This field is only applicable if `statusValidForProcessing` is `true` (indicating a future expiration) or if `statusValidForProcessing` is `false` and `statusReason` is `EXPIRED` (indicating the past expiration date). It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone. Recommended format is yyyy-MM-dd'T'HH:mm:ss.SSSZ (i.e. which allows 2023-07-03T14:27:08.312+02:00 or 2023-07-03T12:27:08.312Z).
-          example: '2023-07-03T14:27:08.312+02:00'
+            The date and time at which the validity of the data processing is set to expire or has expired.
+            It applies mainly to time-limited Consents, or other cases where a specific duration of validity is defined for the data processing. This field is only applicable:
+             
+            - if `statusValidForProcessing` is `true` (indicating a future expiration), or 
+            - if `statusValidForProcessing` is `false` and `statusReason` is `EXPIRED` (indicating the past expiration date). 
+             
+            It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone. Recommended format is yyyy-MM-dd'T'HH:mm:ss.SSSZ (i.e. which allows 2023-07-03T14:27:08.312+02:00 or 2023-07-03T12:27:08.312Z).
+          example: "2023-07-03T14:27:08.312+02:00"
     ErrorInfo:
       type: object
       required:
@@ -417,7 +406,7 @@ components:
       description: Bad Request
       headers:
         x-correlator:
-          $ref: '#/components/headers/x-correlator'
+          $ref: "#/components/headers/x-correlator"
       content:
         application/json:
           schema:
@@ -442,7 +431,7 @@ components:
       description: Unauthorized
       headers:
         x-correlator:
-          $ref: '#/components/headers/x-correlator'
+          $ref: "#/components/headers/x-correlator"
       content:
         application/json:
           schema:
@@ -463,11 +452,11 @@ components:
                 status: 401
                 code: UNAUTHENTICATED
                 message: Request not authenticated due to missing, invalid, or expired credentials.
-    verifyConsentStatus403:
+    retrieveStatus403:
       description: Forbidden
       headers:
         x-correlator:
-          $ref: '#/components/headers/x-correlator'
+          $ref: "#/components/headers/x-correlator"
       content:
         application/json:
           schema:
@@ -506,7 +495,7 @@ components:
       description: Not found
       headers:
         x-correlator:
-          $ref: '#/components/headers/x-correlator'
+          $ref: "#/components/headers/x-correlator"
       content:
         application/json:
           schema:

--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -2,11 +2,11 @@ openapi: 3.0.3
 info:
   title: Consent Info API
   description: |
-    The Consent Info API allows API Consumers to easily validate whether they have the necessary permissions to process User's personal data for a specific Purpose before using other CAMARA APIs. It provides a simple `true`/`false` response and, where applicable, a URL to direct the User to manage their Consent.
+    The Consent Info API allows API Consumers to easily validate whether they have the necessary permissions to process User's personal data for a specific Purpose before using other CAMARA APIs. It provides a simple `true`/`false` response and, when applicable, a URL to direct the User to manage their Consent.
 
     # Introduction
 
-    This API facilitates compliance with privacy regulations and promotes transparency with Users by providing a standardized way to check whether, for example, the User has given their Consent or opted out of data processing. Key inputs include the specific scope(s) of access being requested (i.e. the CAMARA API(s) operations to which the data processing refers), the Purpose for data processing, and a User identifier (either explicitly provided or derived from a three-legged access token). The API responds with the validity status of the data processing, and, where applicable, can provide a capture URL for the API Consumer to manage it.
+    This API facilitates compliance with privacy regulations and promotes transparency with Users by providing a standardized way to check whether, for example, the User has given their Consent or opted out of data processing. Key inputs include the specific scope(s) of access being requested (i.e. the CAMARA API(s) operations to which the data processing refers), the Purpose for data processing, and a User identifier (either explicitly provided or derived from a three-legged access token). The API responds with the validity status of the data processing, and, when applicable, can provide a capture URL for the API Consumer to manage it.
 
     # Relevant terms and definitions
 
@@ -16,7 +16,7 @@ info:
 
     # API Functionality
 
-    This API enables an API Consumer to determine whether the status of data processing is valid or not for a given User, based on the provided scope(s) and Purpose, as well as the API Consumer making the request.
+    This API enables the API Consumer making the request to determine whether its data processing is permitted for a given User, scope(s) and Purpose.
 
     Specifically, the API:
 
@@ -24,7 +24,7 @@ info:
     * **Provides an explanation if invalid**: If data processing is not permitted, the response includes a `statusReason` field to explain why.
     * **Offers a Capture URL (if requested)**: If the status is not valid because user action is required, and the API Consumer sets `requestCaptureUrl` to `true`, the API will return a `captureUrl` field that can be presented to the User. This URL directs them to the API Provider's secure Consent capture channel, where they can provide or renew their Consent.
 
-    **Importantly, this API does NOT delegate Consent capture to the API Consumer but rather empowers the API Consumer to present the API Provider's Consent capture URL at the most opportune time and place. The actual Consent capture occurs within the API Provider's secure environment, ensuring the User's authentication with the API Provider.**
+    Importantly, this API does NOT delegate Consent capture to the API Consumer but rather empowers the API Consumer to present the API Provider's Consent capture URL at the most opportune time and place. The actual Consent capture occurs within the API Provider's secure environment, ensuring the User's authentication with the API Provider.
 
     # Authorization and authentication
 
@@ -70,7 +70,7 @@ paths:
     post:
       summary: Create a request to retrieve the validity status of the data processing
       description: |
-        Create a request to retrieve the validity status of data processing for a given User, based on the provided scope(s) and Purpose, as well as the API Consumer making the request. The API Consumer is identified by the `client_id` parameter deduced from the access token.
+        Create a request to retrieve the validity status of the API Consumer data processing for a given User, scope(s) and Purpose. The API Consumer is identified by the `client_id` parameter deduced from the access token.
       operationId: retrieveStatus
       security:
         - openId:
@@ -371,7 +371,7 @@ components:
                         For example, the User revokes their Consent for the data processing.
             - `OBJECTED`: The user has opted out of the requested data processing, despite a previous explicit opt-in not being required.
                         This is common when the User has exercised their right to object to data processing under the applicable privacy regulations.
-            - `EXPIRED`: Where applicable, the validity of the data processing has ceased due to the passage of time or a pre-defined condition.
+            - `EXPIRED`: When applicable, the validity of the data processing has ceased due to the passage of time or a pre-defined condition.
                         This is common for time-limited Consents.
         expirationDate:
           type: string

--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -3,26 +3,30 @@ info:
   title: Consent Info API
   description: |
 
-    The Consent Info API allows the API Consumer to verify the Consent status of a particular User for that API Consumer and for the requested scope(s) and Purpose. If the Consent is required for the requested scope(s) and Purpose, but has not been granted by the User, the API can also provide a URL pointing to the API Provider's Consent capture channel, enabling the API Consumer to request Consent from the User.
+    The Consent Info API allows an API Consumer to verify the consent status of a particular User for that API Consumer (identified by `client_id` from the access token) concerning requested scope(s) and a specific Purpose. It helps determine if consent is legally required for these parameters. If consent is necessary but not yet granted, or if it has expired, the API can provide a URL pointing to the API Provider's consent capture channel. This enables the API Consumer to direct the User to grant or renew consent in a secure and trusted environment.
 
     # Introduction
+
+    The primary function of this API is to enable API Consumers to ascertain a User's consent preferences before attempting to access or process their personal data via other APIs. By providing a standardized way to check consent, this API facilitates compliance with privacy regulations and promotes transparency with the User. Key inputs include the specific scope(s) of access being requested, the purpose for data processing, and an identifier for the User (either explicitly provided or derived from a three-legged access token). The API responds with the current consent status, the applicable legal basis for data processing, and, if appropriate and requested, a URL for the User to manage their consent.
 
     # Relevant terms and definitions
 
     * **Consent**: An explicit opt-in action that the User takes to allow processing of Personal Data. Consent grants the API Consumer access to a set of scopes related to the User for a specific Purpose.
     * **Purpose**: The reason for which Personal Data will be processed by an API Consumer. CAMARA defines a standard set of Purposes which can be used by API Consumers to specify the reason for their intended Personal Data processing.
+    * **Scope**: A string representing the specific access rights or actions an API Consumer requests from the User for their data (e.g., "location-verification:verify"). A request can contain multiple scopes.
+    * **Legal Basis**: The justification under data protection law for processing personal data. This API uses terms from the W3C Data Privacy Vocabulary (DPV), such as `dpv:Consent`, `dpv:LegitimateInterest`, `dpv:Contract`, etc., to indicate the relevant legal ground.
 
     # API Functionality
 
-    This API enables an API Consumer to determine whether user Consent is required, in the applicable legislation, for the requested actions based on the provide scope(s) and Purpose. NOTE: It may be required more than one User Consent for the requested scope(s) and Purpose (e.g. when the requested scopes are related to multiple APIs).
+    This API enables an API Consumer to determine whether user Consent (or another valid legal basis) is in place for the requested actions, based on the provided scope(s) and Purpose, and for the specific API Consumer making the request. NOTE: The response may contain multiple `consentInfo` array items, for instance, if the requested scopes pertain to different underlying services or require distinct legal assessments (e.g., some scopes rely on `dpv:Consent` while others rely on `dpv:LegitimateInterest`).
 
     Specifically, the API:
 
-    * Determines the need for Consent: Evaluates whether user Consent is necessary according to the specified parameters and relevant legal requirements.
-    * Provides the current Consent status: If Consent is required, the API returns the current status (e.g., active, revoked, expired...) so the API Consumer can understand the current User's consent status.
-    * Offers a Consent Capture URL: If the user has not provided the necessary Consent, the API supplies an API Provider's Consent capture URL where the user can easily complete the Consent process.
+    * Determines the need for Consent or other Legal Basis: Evaluates whether user consent or another legal justification is necessary according to the specified parameters (scopes, Purpose, API Consumer) and relevant legal requirements.
+    * Provides the current Consent status and Legal Basis: If a legal basis is required, the API returns its current status (e.g., `READY`, `PENDING`, `REVOKED`, `EXPIRED`) and the specific type of `legalBasis` (e.g., `dpv:Consent`, `dpv:LegitimateInterest`).
+    * Offers a Consent Capture URL: If the API Consumer sets `requestCaptureUrl` to `true` in the request, and if the user needs to provide or renew consent (e.g., the status is `PENDING` or `EXPIRED` for a `dpv:Consent` legal basis), the API supplies the API Provider's consent capture URL.
 
-    Importantly, this API does NOT delegate consent capture to the API Consumer but rather empowers the API Consumer to present the API Providers's Consent capture URL at the most opportune time and place. The actual Consent capture occurs within the API Provider's secure environment, ensuring the User's authentication with the API Provider.
+    Importantly, this API does NOT delegate consent capture to the API Consumer but rather empowers the API Consumer to present the API Provider's consent capture URL at the most opportune time and place. The actual consent capture occurs within the API Provider's secure environment, ensuring the User's authentication with the API Provider.
 
     # Authorization and authentication
 
@@ -132,45 +136,69 @@ paths:
               schema:
                 $ref: "#/components/schemas/VerifyConsentStatusResponseBody"
               examples:
-                CONSENT_NOT_REQUIRED:
-                  summary: Consent is not required
+                READY_FOR_PROCESSING:
+                  summary: Ready for processing
                   description: |
-                    Consent is not required for the requested scope(s) and Purpose
+                    Data processing is allowed for the requested scope(s) and Purpose.
                   value:
-                    privacyStatus:
+                    consentInfo:
                       - scopes:
                           - "number-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
-                        consentRequired: false
-                CONSENT_REQUIRED_ACTIVE:
-                  summary: Consent is required and active
+                        legalBasis: "dpv:LegitimateInterest"
+                        status: READY
+                CONSENT_REQUIRED:
+                  summary: Consent is required
                   description: |
-                    Consent is required for the requested scope(s) and Purpose and it is provided by the User
+                    Consent is required for the requested scope(s) and Purpose
                   value:
-                    privacyStatus:
+                    consentInfo:
                       - scopes:
                           - "location-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
-                        consentRequired: true
-                        consentStatus: ACTIVE
+                        legalBasis: "dpv:Consent"
+                        status: PENDING
                 CONSENT_REQUIRED_CAPTURE_URL:
-                  summary: Consent is required and capture URL provided
+                  summary: Consent is required and capture URL is provided
                   description: |
-                    Consent is required for the requested scope(s) and Purpose but it is not provided by the User.
+                    Consent is required for the requested scope(s) and Purpose but it is not provided by the User. The API Provider provides a Consent capture URL.
                   value:
-                    privacyStatus:
+                    consentInfo:
                       - scopes:
                           - "location-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
-                        consentRequired: true
-                        consentStatus: PENDING
+                        legalBasis: "dpv:Consent"
+                        status: EXPIRED
+                        expirationDate: '2023-07-03T14:27:08.312+02:00'
                     captureUrl: 'https://example.org/consent-capture-url'
-                CONSENT_REQUIRED_MULTIPLE_SCOPES_ONE_API:
+                CONSENT_REVOKED:
+                  summary: Consent is revoked
+                  description: |
+                    Consent is revoked for the requested scope(s) and Purpose.
+                  value:
+                    consentInfo:
+                      - scopes:
+                          - "location-verification:verify"
+                        purpose: "dpv:FraudPreventionAndDetection"
+                        legalBasis: "dpv:Consent"
+                        status: REVOKED
+                LEGITIMATE_INTEREST_OPT_OUT:
+                  summary: Legitimate interest opt-out
+                  description: |
+                    The User has opted out of the legitimate interest for the requested scope(s) and Purpose.
+                  value:
+                    consentInfo:
+                      - scopes:
+                          - "number-verification:verify"
+                        purpose: "dpv:FraudPreventionAndDetection"
+                        legalBasis: "dpv:LegitimateInterest"
+                        status: REVOKED
+                MULTIPLE_SCOPES_ONE_API:
                   summary: Multiple scopes for one API
                   description: |
-                    Consent is required for the requested scope(s) and Purpose but it is not provided by the User. Request with multiple scopes corresponding to one API.
+                    Request with multiple scopes corresponding to one API.
                   value:
-                    privacyStatus:
+                    consentInfo:
                       - scopes:
                           - "quality-on-demand:sessions:create"
                           - "quality-on-demand:sessions:read"
@@ -178,42 +206,41 @@ paths:
                           - "quality-on-demand:sessions:delete"
                           - "quality-on-demand:sessions:retrieve-by-device"
                         purpose: "dpv:RequestedServiceProvision"
-                        consentRequired: true
-                        consentStatus: PENDING
-                    captureUrl: 'https://example.org/consent-capture-url'
-                CONSENT_REQUIRED_MULTIPLE_SCOPES_MULTIPLE_APIS:
+                        legalBasis: "dpv:Contract"
+                        status: READY
+                MULTIPLE_SCOPES_MULTIPLE_APIS:
                   summary: Multiple scopes for multiple APIs
                   description: |
-                    Consent is required for the requested scope(s) and Purpose but it is not provided by the User. Request with multiple scopes corresponding to multiple APIs.
+                    Request with multiple scopes corresponding to multiple APIs.
                   value:
-                    privacyStatus:
+                    consentInfo:
                       - scopes:
                           - "location-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
-                        consentRequired: true
-                        consentStatus: PENDING
+                        legalBasis: "dpv: Consent"
+                        status: PENDING
                       - scopes:
                           - "device-roaming-status:read"
                         purpose: "dpv:FraudPreventionAndDetection"
-                        consentRequired: true
-                        consentStatus: PENDING
+                        legalBasis: "dpv:Consent"
+                        status: PENDING
                     captureUrl: 'https://example.org/consent-capture-url'
-                MULTIPLES_SCOPES_ONE_API_DIFFERENT_CONSENT_STATUS:
-                  summary: Multiple scopes for one API with different consentStatus
+                MULTIPLES_SCOPES_ONE_API_DIFFERENT_STATUS:
+                  summary: Multiple scopes for one API with different status
                   description: |
-                    Request with multiple scopes corresponding to one API. Different Consent status for each scope.
+                    Request with multiple scopes corresponding to one API. Different status for each scope.
                   value:
-                    privacyStatus:
+                    consentInfo:
                       - scopes:
                           - "sim-swap:check"
                         purpose: "dpv:FraudPreventionAndDetection"
-                        consentRequired: false
+                        legalBasis: "dpv:LegitimateInterest"
+                        status: READY
                       - scopes:
                           - "sim-swap:retrieve-date"
                         purpose: "dpv:FraudPreventionAndDetection"
-                        consentRequired: true
-                        consentStatus: PENDING
-                    captureUrl: 'https://example.org/consent-capture-url'
+                        legalBasis: "dpv:LegitimateInterest"
+                        status: REVOKED
         "400":
           $ref: "#/components/responses/Generic400"
         "401":
@@ -272,7 +299,7 @@ components:
       items:
         type: string
       description: |
-        List of scopes for which the Consent status is requested. The scope is a string that represents the access rights that the API Consumer is requesting from the User.
+        List of requested scopes. The scope is a string that represents the access rights that the API Consumer is requesting from the User.
       example:
         - "location-verification:verify"
     Purpose:
@@ -283,52 +310,72 @@ components:
     VerifyConsentStatusResponseBody:
       type: object
       required:
-        - privacyStatus
+        - consentInfo
       properties:
-        privacyStatus:
-          $ref: "#/components/schemas/PrivacyStatus"
+        consentInfo:
+          $ref: "#/components/schemas/consentInfo"
         captureUrl:
           type: string
           format: url
           description: |
-            URL where the User can provide the necessary Consent. This field is only present if requested by the API Consumer and if `privacyStatus[*].consentRequired` is `true` and its `privacyStatus[*].consentStatus` is `PENDING` or `EXPIRED`.
+            URL where the User can provide the necessary Consent. This field is only present if requested by the API Consumer and if `consentInfo[*].legalBasis` is `dpv:Consent` and its `consentInfo[*].status` is `PENDING` or `EXPIRED`.
           example: 'https://example.org/consent-capture-url'
-    PrivacyStatus:
+    consentInfo:
       type: array
       description: |
-        The PrivacyStatus contains the information about the Consent status for the requested scope(s) and Purpose. It may be required more than one User Consent for the requested scope(s) and Purpose (e.g. when the requested scopes are related to multiple APIs).
+        The consentInfo contains the information about the Consent status for the requested scope(s) and Purpose. It may be required more than one array item for the requested scope(s) and Purpose, e.g. when the requested scopes are related to multiple APIs.
       items:
-        $ref: "#/components/schemas/PrivacyStatusObject"
+        $ref: "#/components/schemas/consentInfoObject"
       minItems: 1
-    PrivacyStatusObject:
+    consentInfoObject:
       type: object
       required:
         - scopes
         - purpose
-        - consentRequired
+        - legalBasis
+        - status
       properties:
         scopes:
           $ref: "#/components/schemas/Scopes"
         purpose:
           $ref: "#/components/schemas/Purpose"
-        consentRequired:
-          type: boolean
+        legalBasis:
+          type: string
           description: |
-            * `true` - The Consent is required for the requested scope(s) and Purpose.
-            * `false` - The Consent is not required for the requested scope(s) and Purpose.
-        consentStatus:
+              The applicable legal basis for the requested scope(s) and Purpose. It uses terms from the W3C [Data Privacy Vocabulary](https://w3c.github.io/dpv/2.1/) (DPV).
+          enum:
+            - dpv:Consent
+            - dpv:LegitimateInterest
+            - dpv:Contract
+            - dpv:LegalObligation
+            - dpv:PublicInterest
+            - dpv:VitalInterest
+        status:
           type: string
           enum:
             - PENDING
-            - ACTIVE
+            - READY
             - REVOKED
             - EXPIRED
           description: |
-            Consent status. This field is only present if `consentRequired` is `true`, in which case it becomes mandatory.
-            - `PENDING`: The User has not provided the necessary Consent yet.
-            - `ACTIVE`: The User has provided the necessary Consent.
-            - `REVOKED`: The User has revoked the necessary Consent.
-            - `EXPIRED`: The Consent provided by the User has expired.
+              Indicates the current validity of the specified `legalBasis` for processing data related to the requested scope(s) and Purpose.
+              It signals if processing is currently allowed and offers a general indication if it is not, if its validity is time-bound, or if it has ceased.
+              Possible values are:
+              - `PENDING`: The specified `legalBasis` is not yet established or fully validated for the requested data processing.
+                           For example, the user has not yet provided Consent under `dpv:Consent` legal basis.
+              - `READY`: The specified `legalBasis` is currently valid and permits the requested data processing.
+                         For example, necessary user Consent has been obtained, a legitimate interests assessment resulted in a positive outcome without overriding objections, or the processing is deemed necessary under an existing contract.
+              - `REVOKED`: Where applicable (primarily for `dpv:Consent` and `dpv:LegitimateInterest`), the user has actively withdrawn their permission, or the previously valid `legalBasis` is no longer considered so due to user action.
+                           This includes revocation of Consent or a successful objection (opt-out) to processing based on legitimate interest.
+              - `EXPIRED`: Where applicable, the validity of the `legalBasis` for data processing has ceased due to the passage of time or a pre-defined condition.
+                           This is common for time-limited Consents or could apply to other bases if their applicability was time-bound.
+        expirationDate:
+          type: string
+          format: date-time
+          description: |
+             The date and time at which the validity of this `legalBasis` is set to expire or has expired.
+             It applies mainly to time-limited legal bases, such as `dpv:Consent`, or others where a specific duration of validity is defined. This field is only present if `status` is `READY` (indicating a future expiration if applicable) or `EXPIRED` (indicating the past expiration date). It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone. Recommended format is yyyy-MM-dd'T'HH:mm:ss.SSSZ (i.e. which allows 2023-07-03T14:27:08.312+02:00 or 2023-07-03T12:27:08.312Z).
+          example: '2023-07-03T14:27:08.312+02:00'
     ErrorInfo:
       type: object
       required:

--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -337,9 +337,9 @@ components:
         Provides information about the data processing validity status for the requested scope(s) and Purpose. It contains details about the applicable Legal Basis, whether it is currently valid for processing data, and if not, the reason why it is not valid. This information helps API Consumers understand the current state of Consent or other Leal Basis for processing data.
         It may be required more than one array item for the requested scope(s) and Purpose, e.g. when the requested scopes are related to multiple APIs.
       items:
-        $ref: "#/components/schemas/consentInfoObject"
+        $ref: "#/components/schemas/statusInfoObject"
       minItems: 1
-    consentInfoObject:
+    statusInfoObject:
       type: object
       required:
         - scopes

--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -3,11 +3,11 @@ info:
   title: Consent Info API
   description: |
 
-    The Consent Info API allows an API Consumer to verify the consent status of a particular User for that API Consumer (identified by `client_id` from the access token) concerning requested scope(s) and a specific Purpose. It helps determine if consent is legally required for these parameters. If consent is necessary but not yet granted, or if it has expired, the API can provide a URL pointing to the API Provider's consent capture channel. This enables the API Consumer to direct the User to grant or renew consent in a secure and trusted environment.
+    The Consent Info API allows an API Consumer to verify the Consent status of a particular User for that API Consumer (identified by `client_id` from the access token) concerning requested scope(s) and a specific Purpose. It helps determine if Consent is legally required for these parameters. If Consent is necessary but not yet granted, or if it has expired, the API can provide a URL pointing to the API Provider's Consent capture channel. This enables the API Consumer to direct the User to grant or renew Consent in a secure and trusted environment.
 
     # Introduction
 
-    The primary function of this API is to enable API Consumers to ascertain a User's consent preferences before attempting to access or process their personal data via other APIs. By providing a standardized way to check consent, this API facilitates compliance with privacy regulations and promotes transparency with users. Key inputs include the specific scope(s) of access being requested, the purpose for data processing, and an identifier for the User (either explicitly provided or derived from a three-legged access token). The API responds with the current consent status, the applicable legal basis for data processing, and, if appropriate and requested, a URL for the User to manage their consent.
+    The primary function of this API is to enable API Consumers to ascertain a User's Consent preferences before attempting to access or process their personal data via other APIs. By providing a standardized way to check Consent, this API facilitates compliance with privacy regulations and promotes transparency with users. Key inputs include the specific scope(s) of access being requested, the purpose for data processing, and an identifier for the User (either explicitly provided or derived from a three-legged access token). The API responds with the current Consent status, the applicable legal basis for data processing, and, if appropriate and requested, a URL for the User to manage their Consent.
 
     # Relevant terms and definitions
 
@@ -22,11 +22,11 @@ info:
 
     Specifically, the API:
 
-    * Determines the need for Consent or other Legal Basis: Evaluates whether user consent or another legal justification is necessary according to the specified parameters (scopes, Purpose, API Consumer) and relevant legal requirements.
+    * Determines the need for Consent or other Legal Basis: Evaluates whether user Consent or another legal justification is necessary according to the specified parameters (scopes, Purpose, API Consumer) and relevant legal requirements.
     * Provides the current Consent status and Legal Basis: If a legal basis is required, the API returns its current status (e.g., `READY`, `PENDING`, `REVOKED`, `EXPIRED`) and the specific type of `legalBasis` (e.g., `dpv:Consent`, `dpv:LegitimateInterest`).
-    * Offers a Consent Capture URL: If the API Consumer sets `requestCaptureUrl` to `true` in the request, and if the user needs to provide or renew consent (e.g., the status is `PENDING` or `EXPIRED` for a `dpv:Consent` legal basis), the API supplies the API Provider's consent capture URL.
+    * Offers a Consent Capture URL: If the API Consumer sets `requestCaptureUrl` to `true` in the request, and if the user needs to provide or renew Consent (e.g., the status is `PENDING` or `EXPIRED` for a `dpv:Consent` legal basis), the API supplies the API Provider's Consent capture URL.
 
-    Importantly, this API does NOT delegate consent capture to the API Consumer but rather empowers the API Consumer to present the API Provider's consent capture URL at the most opportune time and place. The actual consent capture occurs within the API Provider's secure environment, ensuring the User's authentication with the API Provider.
+    Importantly, this API does NOT delegate Consent capture to the API Consumer but rather empowers the API Consumer to present the API Provider's Consent capture URL at the most opportune time and place. The actual Consent capture occurs within the API Provider's secure environment, ensuring the User's authentication with the API Provider.
 
     # Authorization and authentication
 
@@ -293,7 +293,7 @@ components:
           description: |
             A boolean flag indicating whether the API Consumer requests API Provider to return a Consent capture URL.
             * `true` - If set to `true` the API will include a `captureUrl` in the response body if applicable.
-            * `false` - The API will omit the consent capture URL from the response.
+            * `false` - The API will omit the Consent capture URL from the response.
           example: true
     Scopes:
       type: array
@@ -360,7 +360,7 @@ components:
             - REVOKED
             - EXPIRED
           description: |
-              Indicates the current validity of the specified `legalBasis` for processing data related to the requested scope(s) and Purpose.
+              Shows the current validity of the specified `legalBasis` for processing data related to the indicated scope(s) and Purpose.
               It signals if processing is currently allowed and offers a general indication if it is not, if its validity is time-bound, or if it has ceased.
               Possible values are:
               - `PENDING`: The specified `legalBasis` is not yet established or fully validated for the requested data processing.

--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -68,13 +68,13 @@ servers:
         description: API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath`
 tags:
   - name: Verify Status
-    description: Create a request to verify the Consent (or other Legal Basis) status
+    description: Create a request to verify the status of Consent or other Legal Basis
 paths:
   /verify:
     post:
-      summary: Create a request to verify the Consent (or other Legal Basis) status
+      summary: Create a request to verify the status of Consent or other Legal Basis
       description: |
-        Create a request to verify the Consent (or other Legal Basis) status of a specific User to the API Consumer for the requested scope(s) and Purpose. The API Consumer is identified by the `client_id` parameter deduced from the access token.
+        Create a request to verify the Consent or other Legal Basis of a specific User to the API Consumer for the requested scope(s) and Purpose. The API Consumer is identified by the `client_id` parameter deduced from the access token.
       operationId: verifyConsentStatus
       security:
         - openId:
@@ -86,11 +86,11 @@ paths:
       requestBody:
         required: true
         description:
-          Consent status verification request
+          Status verification request
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/VerifyConsentStatusRequestBody"
+              $ref: "#/components/schemas/VerifyStatusRequestBody"
             examples:
               ONE_SCOPE_ONE_API:
                 summary: One scope
@@ -136,7 +136,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/VerifyConsentStatusResponseBody"
+                $ref: "#/components/schemas/VerifyStatusResponseBody"
               examples:
                 READY_FOR_PROCESSING:
                   summary: Ready for processing
@@ -282,10 +282,10 @@ components:
       description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, prefixed with '+'.
       pattern: '^\+[1-9][0-9]{4,14}$'
       example: "+123456789"
-    VerifyConsentStatusRequestBody:
+    VerifyStatusRequestBody:
       type: object
       description: |
-        The request body for the Consent status verification request. It contains the requested scope(s), the Purpose for which the API Consumer intends to process the User's Personal Data, a flag indicating whether the API Consumer requests a Consent capture URL and optionally the phone number of the User. The phone number is required when the API is invoked using a two-legged access token, but MUST NOT be provided when a three-legged access token is used, as the subject will be uniquely identified from the access token.
+        The request body for the status verification request. It contains the requested scope(s), the Purpose for which the API Consumer intends to process the User's Personal Data, a flag indicating whether the API Consumer requests a Consent capture URL and optionally the phone number of the User. The phone number is required when the API is invoked using a two-legged access token, but MUST NOT be provided when a three-legged access token is used, as the subject will be uniquely identified from the access token.
       required:
         - scopes
         - purpose
@@ -318,7 +318,7 @@ components:
       description: |
         The reason for which Personal Data will be processed by the API Consumer. CAMARA defines a standard set of Purposes which can be used by API Consumers to specify the reason for their intended Personal Data processing.
       example: "dpv:FraudPreventionAndDetection"
-    VerifyConsentStatusResponseBody:
+    VerifyStatusResponseBody:
       type: object
       required:
         - statusInfo

--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -318,7 +318,7 @@ components:
             URL where the User can provide the necessary Consent. This field is only present in the API response if the API Consumer requests it and if the following conditions are met:
 
             - `statusInfo[*].statusValidForProcessing` is `false`, and
-            - `statusInfo[*].statusReason` is `PENDING`, `REQUESTED` or `EXPIRED`. 
+            - `statusInfo[*].statusReason` is `PENDING`, `REQUESTED` or `EXPIRED`.
 
             Please note that this field is only applicable when the User Consent is required to enable valid data processing. A unique URL is provided to authorise all items in the statusInfo list that require user action.
           example: "https://example.org/consent-capture-url"
@@ -358,9 +358,9 @@ components:
             - OBJECTED
           description: |
             This field must be present if `statusValidForProcessing` is `false`. It indicates the reason why the requested data processing is not permitted for the specified scope(s) and Purpose. It provides API Consumers with additional context on the current validity status, helping them to understand its applicability and the next steps they may need to take.
-              
+
             It is particularly useful for determining whether the API Consumer should prompt the User to take action, such as providing Consent or renewing an existing Consent.
-              
+
             Possible values are:
 
             - `PENDING`: The requested data processing has not yet been established or fully validated under the applicable privacy regulations.
@@ -379,10 +379,10 @@ components:
           description: |
             The date and time at which the validity of the data processing is set to expire or has expired.
             It applies mainly to time-limited Consents, or other cases where a specific duration of validity is defined for the data processing. This field is only applicable:
-             
-            - if `statusValidForProcessing` is `true` (indicating a future expiration), or 
-            - if `statusValidForProcessing` is `false` and `statusReason` is `EXPIRED` (indicating the past expiration date). 
-             
+
+            - if `statusValidForProcessing` is `true` (indicating a future expiration), or
+            - if `statusValidForProcessing` is `false` and `statusReason` is `EXPIRED` (indicating the past expiration date).
+
             It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone. Recommended format is yyyy-MM-dd'T'HH:mm:ss.SSSZ (i.e. which allows 2023-07-03T14:27:08.312+02:00 or 2023-07-03T12:27:08.312Z).
           example: "2023-07-03T14:27:08.312+02:00"
     ErrorInfo:

--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -217,7 +217,7 @@ paths:
                       - scopes:
                           - "location-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
-                        legalBasis: "dpv: Consent"
+                        legalBasis: "dpv:Consent"
                         status: PENDING
                       - scopes:
                           - "device-roaming-status:read"
@@ -275,6 +275,8 @@ components:
       example: "+123456789"
     VerifyConsentStatusRequestBody:
       type: object
+      description: |
+        The request body for the Consent status verification request. It contains the requested scope(s), the Purpose for which the API Consumer intends to process the User's Personal Data, a flag indicating whether the API Consumer requests a Consent capture URL and optionally the phone number of the User. The phone number is required when the API is invoked using a two-legged access token, but MUST NOT be provided when a three-legged access token is used, as the subject will be uniquely identified from the access token.
       required:
         - scopes
         - purpose


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:

As agreed in the last ICM call (https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/131399863/2025-06-04+Draft+Agenda+ICM+Minutes), this PR incorporates the proposed changes to the API spec by Telefónica to facilitate further discussion and agreement.

This PR builds on the existing Consent Info API to provide a better model for the expected functional scope, including simplified statuses, a legal basis for responses (following DPV defined legal basis), coverage of the Legitimate Interest opt-out scenario and an expiration date where applicable...

#### Which issue(s) this PR fixes:

Fixes #9
Fixes #10 
Fixes #15 
Fixes #19
Fixes #26 

#### Special notes for reviewers:

CC @HuubAppelboom @subha5h

These changes collectively improve the API's ability to handle complex consent scenarios, enhance compliance, and provide clearer documentation for developers.

**Regarding issue #11, we can discuss it further in @subha5h's PR https://github.com/camaraproject/ConsentInfo/pull/20.** That issue is NOT covered in this PR.

#### Changelog input

```
 API spec update 
```

#### Additional documentation 

N/A