### PR TITLE
Reset version to wip after Fall25 public release

### DIFF
--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -62,13 +62,13 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.1.0
+  version: wip
   x-camara-commonalities: 0.6
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/ConsentInfo
 servers:
-  - url: "{apiRoot}/consent-info/v0.1"
+  - url: "{apiRoot}/consent-info/vwip"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/Test_definitions/consent-info.feature
+++ b/code/Test_definitions/consent-info.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Consent Info API, v0.1.0 - Operation retrieveStatus
+Feature: CAMARA Consent Info API, vwip - Operation retrieveStatus
   # Input to be provided by the implementation to the tester
   #
   # Implementation indications:
@@ -11,7 +11,7 @@ Feature: CAMARA Consent Info API, v0.1.0 - Operation retrieveStatus
 
   Background: Common retrieveStatus setup
     Given an environment at "apiRoot"
-    And the resource "/consent-info/v0.1/retrieve"
+    And the resource "/consent-info/vwip/retrieve"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"


### PR DESCRIPTION
#### What type of PR is this?

* repository management

#### What this PR does / why we need it:

Set version across API and Test definitions to `wip` to prepare the repository for the work on Spring26/next release.


#### Which issue(s) this PR fixes:

Fixes #37

#### Special notes for reviewers:

N/A

#### Changelog input

N/A

#### Additional documentation 

N/A
