### PR TITLE
chore(workflow): sync release automation caller template

### DIFF
--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -54,6 +54,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release-automation:
@@ -80,4 +81,6 @@ jobs:
        startsWith(github.event.pull_request.base.ref, 'release-snapshot/'))
 
     uses: camaraproject/tooling/.github/workflows/release-automation-reusable.yml@ra-v1-rc
+    # with:
+    #   tooling_ref_override: "0123456789abcdef0123456789abcdef01234567"  # Optional break-glass SHA override (requires workflow file change)
     secrets: inherit


### PR DESCRIPTION
#### What type of PR is this?

repository management

#### What this PR does / why we need it:

- Sync `.github/workflows/release-automation.yml` with the current CAMARA tooling caller template.
- Add `permissions: id-token: write` so the reusable workflow can read OIDC `job_workflow_sha` metadata and resolve the exact called-workflow commit.
- Add a commented `with.tooling_ref_override` break-glass line for explicit emergency override usage (no active caller input added).
- Keep the caller pinned to `camaraproject/tooling/...@ra-v1-rc`.

#### Which issue(s) this PR fixes:

Not fixing a ConsentInfo repository issue.
Related: https://github.com/camaraproject/tooling/issues/110

#### Special notes for reviewers:

- Tooling implementation is merged in https://github.com/camaraproject/tooling/pull/111.
- The `ra-v1-rc` tag was moved to include that implementation before opening this caller update.

#### Changelog input

```
release-note
- Update release automation caller workflow permissions/template for OIDC-based reusable workflow ref resolution.
```

#### Additional documentation

```
docs
```
