### PR TITLE
chore: complete CHANGELOG migration to per-cycle files

### DIFF
--- a/CHANGELOG/CHANGELOG-r1.md
+++ b/CHANGELOG/CHANGELOG-r1.md
@@ -1,13 +1,10 @@
-> Starting with release automation, new release changelogs are maintained
-> in the [CHANGELOG/](CHANGELOG/) directory with per-cycle files.
-
 # Changelog ConsentInfo
 
-## Table of contents
-
-- **[r2.1](#r21)**
-- **[r1.2](#r12)**
-- **[r1.1](#r11)**
+<!-- TOC:START -->
+## Table of Contents
+- [r1.2](#r12)
+- [r1.1](#r11)
+<!-- TOC:END -->
 
 **Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until it has been released. For example, changes may be reverted before a release is published. For the best results, use the latest published release.**
 
@@ -17,52 +14,6 @@ The below sections record the changes for each API version in each release as fo
 * for the first release-candidate, all changes since the last public release
 * for subsequent release-candidate(s), only the delta to the previous release-candidate
 * for a public release, the consolidated changes since the previous public release
-
-<!--Repeat the below release section (header 1 and subsections) at the top of this file for each new (pre-)release-->
-
-# r2.1
-
-## Release Notes
-
-This release contains the definition and documentation of
-* consent-info v0.2.0-rc.1
-
-The API definition(s) are based on
-* Commonalities r3.4
-* Identity and Consent Management r3.3
-
-## consent-info v0.2.0-rc.1
-
-**consent-info v0.2.0-rc.1 is the first release candidate of the version 0.2.0**
-
-consent-info API v0.2.0 introduces enhancements to improve user experience and clarity in consent management. Key updates include the addition of an optional `callbackUrl` parameter for redirecting users post-consent, refined status terminology replacing `REVOKED` with `DENIED`, and expanded test scenarios to ensure robust handling of new features.
-  
-- API definition **with inline documentation**:
-  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/ConsentInfo/r2.1/code/API_definitions/consent-info.yaml&nocors)
-  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/ConsentInfo/r2.1/code/API_definitions/consent-info.yaml)
-  - OpenAPI [YAML spec file](https://github.com/camaraproject/ConsentInfo/blob/r2.1/code/API_definitions/consent-info.yaml)
-
-### Added
-
-- Added support for an optional `callbackUrl` parameter in the consent capture request, allowing API Consumers to specify where the user should be redirected after completing the consent flow by @jpengar in https://github.com/camaraproject/ConsentInfo/pull/41
-- Added error code `CONSENT_INFO.INVALID_CALLBACK_URL` and example for invalid callback URLs, ensuring that API Providers return a clear 403 error when the callback URL fails validation by @jpengar in https://github.com/camaraproject/ConsentInfo/pull/41
-- Included a new request example `ONE_SCOPE_CALLBACK_URL` demonstrating usage of the `callbackUrl field in API requests by @jpengar in https://github.com/camaraproject/ConsentInfo/pull/41
-- Added a new response example `CONSENT_DENIED` to illustrate how the API responds when consent is explicitly denied for a scope and purpose by @jpengar in https://github.com/camaraproject/ConsentInfo/pull/41
-- Extended test scenarios to cover callback URL behavior, including handling the `state` parameter and verifying correct redirection and result propagation by @jpengar in https://github.com/camaraproject/ConsentInfo/pull/41
-
-### Changed
-
-- Replaced the status value `REVOKED` with `DENIED` throughout the API, updating both the schema and the documentation to clarify that `DENIED` covers both explicit refusal and withdrawal of consent by @jpengar in https://github.com/camaraproject/ConsentInfo/pull/41
-
-### Fixed
-
-- N/A
-
-### Removed
-
-- N/A
-
-**Full Changelog**: https://github.com/camaraproject/ConsentInfo/compare/r1.2...r2.1
 
 # r1.2
 

--- a/CHANGELOG/README.md
+++ b/CHANGELOG/README.md
@@ -2,5 +2,5 @@
 
 Release changelogs are organized by release cycle.
 
-For historical release notes predating the automated release process,
-see [CHANGELOG.md](../CHANGELOG.md) in the repository root.
+- [CHANGELOG-r2.md](CHANGELOG-r2.md)
+- [CHANGELOG-r1.md](CHANGELOG-r1.md)

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,8 +11,3 @@
 # Owners of the CODEOWNER and Maintainer.md files are the admins of CAMARA (to allow them to keep the teams within the CAMARA organization in sync in case of changes)
 /CODEOWNERS @camaraproject/admins
 /MAINTAINERS.MD @camaraproject/admins
-
-# The following lines ensure that the release-management_reviewers team will automatically added as reviewers
-# if a pull requests is changing the CHANGELOG file (aka "release PR") and that such PRs can only be merged with an approval from a team member.
-/CHANGELOG.MD @camaraproject/release-management_reviewers
-/CHANGELOG.md @camaraproject/release-management_reviewers


### PR DESCRIPTION
#### What type of PR is this?

cleanup

#### What this PR does / why we need it:

Completes the migration from a single `CHANGELOG.md` to per-cycle files in `CHANGELOG/`:

- Moves `CHANGELOG.md` → `CHANGELOG/CHANGELOG-r1.md` (retains r1.1 and r1.2 entries)
- Removes r2.1 from the moved file (already present in `CHANGELOG/CHANGELOG-r2.md` created by release automation)
- Updates `CHANGELOG/README.md` to index both cycle files

#### Which issue(s) this PR fixes:

N/A

#### Special notes for reviewers:

The diff should show `CHANGELOG.md` as renamed to `CHANGELOG/CHANGELOG-r1.md` with the r2.1 section removed.

#### Changelog input

```
release-note-none
```

#### Additional documentation

```
docs-none
```