### PR TITLE
Plan update for public release r2.3

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -16,11 +16,11 @@ repository:
   # Initialized to the latest release; update when planning the next release.
   # - New release cycle (increment first number, reset second to 1)
   # - Progression in same cycle (increment second number)
-  target_release_tag: r2.2
+  target_release_tag: r2.3
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: pre-release-rc
+  target_release_type: public-release
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
@@ -34,7 +34,7 @@ dependencies:
 apis:
   - api_name: consent-info
     target_api_version: 0.2.0
-    target_api_status: rc
+    target_api_status: public
     main_contacts:
       - jpengar
       - AxelNennker


### PR DESCRIPTION
#### What type of PR is this?

* repository management

#### What this PR does / why we need it:

This pull request updates the release planning configuration to move the project from release candidate (RC) status to a public release. The changes ensure that both the main repository and the `consent-info` API are aligned with the new public release cycle.

Release plan updates:

* Updated `target_release_tag` in `release-plan.yaml` to `r2.3`, indicating the start of a new release cycle.
* Changed `target_release_type` in `release-plan.yaml` from `pre-release-rc` to `public-release`, signaling readiness for a public release.
* Updated `target_api_status` from `rc` to `public` in `release-plan.yaml`, reflecting the target public release.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for reviewers:

This is a prerequisite for starting the automated generation of the public release.

#### Changelog input

```
Plan update for public release r2.3
```

#### Additional documentation 

- https://github.com/camaraproject/ReleaseManagement/blob/main/documentation/README.md
- https://github.com/camaraproject/ReleaseManagement/blob/main/documentation/release-process/lifecycle.md
